### PR TITLE
Various tweaks

### DIFF
--- a/client/src/components/ai-chat/index.tsx
+++ b/client/src/components/ai-chat/index.tsx
@@ -205,7 +205,7 @@ export function AIChat({ tapestryId, canAttachItems, onPickingItems }: AIChatPro
         )}
         {lastUserMessageState === 'pending' && <LoadingDots />}
         {lastUserMessageState === 'error' && (
-          <Text variant="bodyXs" className={styles.errorMessage}>
+          <Text variant="bodyXs" textType="error" className={styles.errorMessage}>
             Your message could not be processed. <br />
             Please make sure{' '}
             <Link to={userProfilePath('ai-assistants')} target="_blank">

--- a/client/src/components/ai-chat/styles.module.css
+++ b/client/src/components/ai-chat/styles.module.css
@@ -97,7 +97,6 @@
     }
 
     .error-message {
-      color: var(--theme-text-negative);
       padding: 8px;
       text-align: center;
     }

--- a/client/src/components/tapestry-dialog/index.tsx
+++ b/client/src/components/tapestry-dialog/index.tsx
@@ -1,13 +1,13 @@
+import { trim, uniqueId } from 'lodash'
 import { useRef, useState } from 'react'
 import { Input } from 'tapestry-core-client/src/components/lib/input/index'
 import { SimpleModal } from 'tapestry-core-client/src/components/lib/modal/index'
+import { Text } from 'tapestry-core-client/src/components/lib/text/index'
+import { getErrorMessage } from '../../errors'
+import { useSession } from '../../layouts/session'
+import { tapestryPath } from '../../utils/paths'
 import { Textarea } from '../textarea'
 import styles from './styles.module.css'
-import { trim, uniqueId } from 'lodash-es'
-import { getErrorMessage } from '../../errors'
-import { Text } from 'tapestry-core-client/src/components/lib/text/index'
-import { tapestryPath } from '../../utils/paths'
-import { useSession } from '../../layouts/session'
 
 export interface TapestryInfo {
   title: string
@@ -21,7 +21,7 @@ interface TapestryDialogProps {
   cancelText?: string
   onClose?: () => unknown
   onCancel: () => unknown
-  handleSubmit: (tapestryInfo: TapestryInfo) => Promise<void>
+  handleSubmit: (tapestryInfo: TapestryInfo) => unknown
   error?: unknown
   tapestryInfo?: TapestryInfo
   hideSlug?: boolean
@@ -47,6 +47,8 @@ export function TapestryDialog({
   const [tapestryInfo, setTapestryInfo] = useState<Partial<TapestryInfo>>(initialTapestryInfo ?? {})
   const { slug } = tapestryInfo
 
+  const formError = getErrorMessage(error)
+
   return (
     <SimpleModal
       classes={{ root: styles.modal }}
@@ -60,7 +62,7 @@ export function TapestryDialog({
         className={styles.form}
         onSubmit={(e) => {
           e.preventDefault()
-          void handleSubmit({
+          handleSubmit({
             title: tapestryInfo.title ?? '',
             slug,
             description: tapestryInfo.description,
@@ -100,7 +102,7 @@ export function TapestryDialog({
               className={styles.input}
               typography="body"
             />
-            {username && slug && (
+            {username && slug?.trim() && (
               <Text
                 variant="bodyXs"
                 style={{ color: 'var(--theme-text-tertiary)' }}
@@ -121,8 +123,12 @@ export function TapestryDialog({
           onSubmit={(e) => (e.target as HTMLTextAreaElement).form?.requestSubmit()}
           typography="body"
         />
-        <input type="submit" hidden />
       </form>
+      {formError && (
+        <Text variant="bodySm" textType="error">
+          {formError}
+        </Text>
+      )}
     </SimpleModal>
   )
 }

--- a/client/src/errors/index.ts
+++ b/client/src/errors/index.ts
@@ -36,5 +36,8 @@ export function getErrorMessage(error: unknown, name?: string, overrides?: Parti
         return overrides?.[code] ?? FIELD_ERROR_CODE_MESSAGES[code]
       }
     }
+    if (error.data.name === 'ForbiddenError' && !name) {
+      return "You don't have permissions to perform this action"
+    }
   }
 }

--- a/client/src/pages/user-profile/ai-assistant-setup/index.tsx
+++ b/client/src/pages/user-profile/ai-assistant-setup/index.tsx
@@ -15,7 +15,7 @@ interface AIAssistantSetupProps {
 }
 
 export function AIAssistantSetup({ user }: AIAssistantSetupProps) {
-  const [isAdding, setIsAdding] = useState(false)
+  const [isAdding, setIsAdding] = useState<'guide' | 'input'>()
 
   const {
     data: secrets,
@@ -30,12 +30,12 @@ export function AIAssistantSetup({ user }: AIAssistantSetupProps) {
     [user.id],
   )
 
-  function openDialog() {
-    setIsAdding(true)
+  function openDialog(state: NonNullable<typeof isAdding>) {
+    setIsAdding(state)
   }
 
   function closeDialog() {
-    setIsAdding(false)
+    setIsAdding(undefined)
   }
 
   return (
@@ -46,8 +46,11 @@ export function AIAssistantSetup({ user }: AIAssistantSetupProps) {
           <Text variant="h4" className={styles.emptyMessage}>
             No API Keys found
           </Text>
-          <Button icon="add" onClick={openDialog}>
+          <Button icon="add" onClick={() => openDialog('input')}>
             Add new
+          </Button>
+          <Button variant="link" onClick={() => openDialog('guide')}>
+            Need help?
           </Button>
         </div>
       )}
@@ -69,7 +72,7 @@ export function AIAssistantSetup({ user }: AIAssistantSetupProps) {
               <div className={styles.buttons}>
                 {/* Currently a user can have at most one Gemini API key. Once we start supporting other AI providers,
                 users will be able to add more keys. */}
-                <Button icon="add" onClick={openDialog} disabled>
+                <Button icon="add" onClick={() => openDialog('input')} disabled>
                   Add new key
                 </Button>
               </div>
@@ -81,6 +84,7 @@ export function AIAssistantSetup({ user }: AIAssistantSetupProps) {
         <ApiKeyDialog
           user={user}
           onClose={closeDialog}
+          showGuide={isAdding === 'guide'}
           onSubmitted={() => {
             closeDialog()
             reload(noop)

--- a/core-client/src/components/lib/input/index.tsx
+++ b/core-client/src/components/lib/input/index.tsx
@@ -39,7 +39,7 @@ export function Input({
         onCopy={(e) => e.stopPropagation()}
       />
       {error && (
-        <Text variant="bodySm" className={styles.error}>
+        <Text variant="bodySm" textType="error">
           {error}
         </Text>
       )}

--- a/core-client/src/components/lib/input/styles.module.css
+++ b/core-client/src/components/lib/input/styles.module.css
@@ -17,10 +17,6 @@
   }
 }
 
-.error {
-  color: var(--theme-text-negative);
-}
-
 .input-label {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
* Showing an error message in case there is an error when forking a tapestry (could handle a very obscure scenario where a user has opened the fork dialog and prior to them submitting the tapestry, the author forbids the making of copies)

  * Changed the `getErrorMessage` function so that in case the user hasn't passed in the `name` parameter (i.e. passing it would mean that they are intereseted in a `BadRequestError`) a default message is returned when the error is a `ForbiddenError`
* Added the `Need help?` link button on the ai-assistant setup page
* Not showing the tapestry url if the slug is comprised of whitespaces only