### PR TITLE
Remove shadows from item snapshots

### DIFF
--- a/client/src/components/toolbars/zoom/index.tsx
+++ b/client/src/components/toolbars/zoom/index.tsx
@@ -17,10 +17,11 @@ interface ZoomControlsProps {
 
 export function ZoomToolbar({ className }: ZoomControlsProps) {
   const obstruction = useViewportObstruction({ clear: { bottom: true, right: true } })
-  const { userAccess, interactionMode, hideEditControls } = useTapestryData([
+  const { userAccess, interactionMode, hideEditControls, hideControls } = useTapestryData([
     'userAccess',
     'interactionMode',
     'hideEditControls',
+    'hideControls',
   ])
 
   const canEdit = userAccess === 'edit'
@@ -65,6 +66,10 @@ export function ZoomToolbar({ className }: ZoomControlsProps) {
       'fullscreen',
     ],
   )
+
+  if (hideControls) {
+    return null
+  }
 
   return (
     <Toolbar

--- a/client/src/model/data/utils.ts
+++ b/client/src/model/data/utils.ts
@@ -161,6 +161,7 @@ export function fromTapestryDto(
   commentThreads: CommentThreadsDto,
   presentationSteps: PresentationStepDto[],
   deoptimize: boolean,
+  hideControls: boolean,
 ): EditableTapestryViewModel {
   const presentationStepViewModels = presentationSteps.map((dto) => ({ dto }))
 
@@ -177,6 +178,7 @@ export function fromTapestryDto(
   const editableTapestryViewModel: EditableTapestryViewModel = {
     ...baseViewModel,
     disableOptimizations: mode === 'edit' || deoptimize,
+    hideControls,
     items: Object.fromEntries(tapestry.items?.map((item) => [item.id, { dto: item }]) ?? []),
     rels: Object.fromEntries(tapestry.rels?.map((rel) => [rel.id, { dto: rel }]) ?? []),
     groups: Object.fromEntries(tapestry.groups?.map((group) => [group.id, { dto: group }]) ?? []),

--- a/client/src/pages/tapestry/tapestry-loader.tsx
+++ b/client/src/pages/tapestry/tapestry-loader.tsx
@@ -121,7 +121,14 @@ export function TapestryLoader({ id, mode }: TapestryLoaderProps) {
       }
 
       const deopt = !!searchParams.get('deopt')
-      const dataSync = new TapestryDataSync(id, canEdit ? mode : 'view', userAccess, deopt)
+      const hideControls = !!searchParams.get('hideControls')
+      const dataSync = new TapestryDataSync(
+        id,
+        canEdit ? mode : 'view',
+        userAccess,
+        deopt,
+        hideControls,
+      )
       onCleanup(() => dataSync.dispose())
 
       await dataSync.init(signal)

--- a/client/src/pages/tapestry/tapestry.tsx
+++ b/client/src/pages/tapestry/tapestry.tsx
@@ -63,9 +63,10 @@ export function Tapestry() {
   const pixiContainerRef = useRef<HTMLDivElement>(null)
   const presentationOrderContainerRef = useRef<HTMLDivElement>(null)
   const tapestryTitle = useTapestryData('title')
-  const { presentationOrderState, hideEditControls } = useTapestryData([
+  const { presentationOrderState, hideEditControls, hideControls } = useTapestryData([
     'presentationOrderState',
     'hideEditControls',
+    'hideControls',
   ])
   const documentTitle = `Tapestry - ${tapestryTitle}`
 
@@ -112,14 +113,14 @@ export function Tapestry() {
         <ViewportScrollbars />
       </div>
       <QuickTips />
-      <MainToolbar className={styles.mainToolbar} />
+      {!hideControls && <MainToolbar className={styles.mainToolbar} />}
       <TapestrySnackbar />
       {!hideEditControls && (
         <>
           <div className={styles.usersData}>
             <DoingWorkIndicator />
             <CollaboratorIndicators />
-            <UserToolbar />
+            {!hideControls && <UserToolbar />}
           </div>
           <CollaboratorCursors />
         </>

--- a/client/src/pages/tapestry/view-model/tapestry-data-sync.ts
+++ b/client/src/pages/tapestry/view-model/tapestry-data-sync.ts
@@ -99,6 +99,7 @@ export class TapestryDataSync {
     private initialMode: InteractionMode,
     private userAccess: UserAccess,
     private deoptimize: boolean,
+    private hideControls: boolean,
   ) {
     this.socketManager = new SocketManager(tapestryId)
     // The conversion is made because TS forbids more generic add/remove event listener functions
@@ -150,6 +151,7 @@ export class TapestryDataSync {
       commentThreads,
       idMapToArray(this.tapestryRepo.value.presentationSteps),
       this.deoptimize,
+      this.hideControls,
     )
     this._store = new Store(tapestryViewModel, [
       {

--- a/core-client/src/components/tapestry/zoom/index.tsx
+++ b/core-client/src/components/tapestry/zoom/index.tsx
@@ -3,6 +3,7 @@ import { Toolbar } from '../../../../src/components/lib/toolbar/index'
 import { useViewportObstruction } from '../hooks/use-viewport-obstruction'
 import { useZoomToolbarItems } from '../hooks/use-zoom-toolbar-items'
 import styles from './styles.module.css'
+import { useTapestryConfig } from '..'
 
 interface ZoomControlsProps {
   className?: string
@@ -11,10 +12,17 @@ interface ZoomControlsProps {
 export function ZoomToolbar({ className }: ZoomControlsProps) {
   const obstruction = useViewportObstruction({ clear: { bottom: true, right: true } })
 
+  const { useStoreData } = useTapestryConfig()
+  const hideControls = useStoreData('hideControls')
+
   const { items, closeSubmenu, selectedSubmenu } = useZoomToolbarItems(
     ['zoom-out', 'zoom-in', 'zoom-to-fit'],
     ['guide', 'shortcuts', 'separator', 'start-presentation', 'fullscreen'],
   )
+
+  if (hideControls) {
+    return null
+  }
 
   return (
     <Toolbar

--- a/core-client/src/view-model/index.ts
+++ b/core-client/src/view-model/index.ts
@@ -129,6 +129,7 @@ export interface TapestryViewModel<
    * these optimizations are used when displaying the tapestry or not.
    */
   readonly disableOptimizations?: boolean
+  readonly hideControls?: boolean
   readonly outlinedItemId?: string
   readonly searchTerm?: string | null
   readonly items: Readonly<IdMap<I>>

--- a/server/src/tasks/thumbnail-generators/tapestry.ts
+++ b/server/src/tasks/thumbnail-generators/tapestry.ts
@@ -38,9 +38,9 @@ async function takeItemScreenshot(page: Page, item: Item) {
 
   await page.setViewport({
     // The browser window should be larger than the required element size in order to accommodate
-    // for the tapestry controls around it.
-    width: size.width + 100,
-    height: size.height + 300,
+    // for the element toolbar space
+    width: size.width,
+    height: size.height + 100,
     deviceScaleFactor: 2,
   })
 
@@ -100,6 +100,7 @@ export async function* takeTapestryScreenshots(
 ) {
   const url = new URL(tapestryPath, config.server.viewerUrl)
   url.searchParams.set('deopt', '1')
+  url.searchParams.set('hideControls', '1')
   const src = url.toString()
   const { windowSize, timeout } = site
   console.log(`Taking screenshots of ${src}...`)

--- a/viewer/src/components/tapestry/index.tsx
+++ b/viewer/src/components/tapestry/index.tsx
@@ -17,7 +17,7 @@ import { ViewportController } from 'tapestry-core-client/src/stage/controller/vi
 import { ItemThumbnailController } from 'tapestry-core-client/src/stage/controller/item-thumbnail-controller'
 import { TapestryRenderer } from 'tapestry-core-client/src/stage/renderer'
 import { idMapToArray } from 'tapestry-core/src/utils'
-import { useTapestryStore } from '../../app'
+import { useTapestryData, useTapestryStore } from '../../app'
 import { SidePane } from '../side-pane'
 import { TopToolbar } from '../top-toolbar'
 
@@ -31,6 +31,8 @@ export function Tapestry({ onBack }: TapestryProps) {
   const navigate = useNavigate()
 
   const store = useTapestryStore()
+
+  const hideControls = useTapestryData('hideControls')
 
   useStageInit(sceneRef, {
     gestureDetectorOptions: { scrollGesture: 'pan', dragToPan: store.get('pointerMode') === 'pan' },
@@ -90,7 +92,7 @@ export function Tapestry({ onBack }: TapestryProps) {
         <TapestryCanvas classes={{ root: 'dom-container' }} />
         <ViewportScrollbars />
       </div>
-      <TopToolbar onBack={onBack} />
+      {!hideControls && <TopToolbar onBack={onBack} />}
       <SidePane />
       <ZoomToolbar className="zoom-toolbar" />
     </>


### PR DESCRIPTION
Added a new hideControls property, which hides all tapestry page toolbars while preserving zoom toolbar keyboard shortcuts function.
This could be used in #30.