### PR TITLE
Fix pdf unfocus

### DIFF
--- a/client/src/components/tapestry-elements/items/pdf/index.tsx
+++ b/client/src/components/tapestry-elements/items/pdf/index.tsx
@@ -55,7 +55,7 @@ export const PdfItem = memo(({ id }: TapestryItemProps) => {
         omit: { share: !pdfDocument },
       })
 
-      return isEdit ? [...pageSelector, ...controls] : [...pageSelector, ...controls]
+      return [...pageSelector, ...controls]
     },
     moreMenuItems: pdfDocument
       ? [

--- a/core-client/src/components/lib/toolbar/index.tsx
+++ b/core-client/src/components/lib/toolbar/index.tsx
@@ -20,6 +20,7 @@ export type SubmenuIds<T, D extends number = 10> = [D] extends [never]
 
 export interface ToolbarElement {
   element: ReactElement
+  key?: string
   tooltip?: TooltipProps
   badge?: string | boolean
 }
@@ -46,7 +47,7 @@ export function isMultiLineMenu(items: MenuItems | ReactNode): items is MaybeMen
   return Array.isArray(items) && Array.isArray(items[0])
 }
 
-function isToolbarElement(elem: ReactElement | ToolbarElement): elem is ToolbarElement {
+function isToolbarElement(elem: SimpleMenuItem): elem is ToolbarElement {
   return !!(elem as ToolbarElement).element
 }
 
@@ -94,7 +95,7 @@ function ToolbarRow({ items, selectedSubmenu }: ToolbarRowProps) {
                 />
               </div>
             ) : (
-              <SimpleMenuItem key={index} ui={item} />
+              <SimpleMenuItem key={(isToolbarElement(item) && item.key) || index} ui={item} />
             ),
           )
         : items}

--- a/core-client/src/components/tapestry/hooks/use-item-menu.tsx
+++ b/core-client/src/components/tapestry/hooks/use-item-menu.tsx
@@ -49,6 +49,7 @@ export function useItemMenu<const M extends string>(
       if (menuItem === 'focus') {
         return {
           element: <FocusButton onFocus={() => focusElement(itemId)} />,
+          key: 'focus',
           tooltip: { side: 'bottom', children: <ShortcutLabel text="Focus">F</ShortcutLabel> },
         }
       }


### PR DESCRIPTION
After the pdf loads a new toolbar menu item gets added for browsing pages, which causes the remount of all menu items. That is why a key should be used to preserve the focus button's state. 