### PR TITLE
Implement webpage to PDF conversion

### DIFF
--- a/client/src/components/tapestry-elements/items/webpage/index.tsx
+++ b/client/src/components/tapestry-elements/items/webpage/index.tsx
@@ -79,7 +79,7 @@ function Webpage({ src, onLoad, ...props }: WebFrameSwitchProps) {
     <div className={styles.error}>
       <Icon icon="sentiment_very_dissatisfied" />
       <Text>{`Cannot frame ${src}`}</Text>
-      <Text>{`Switch to wayback machine version or convert to PDF.`}</Text>
+      <Text>Switch to wayback machine version or convert to PDF.</Text>
     </div>
   ) : null
 }

--- a/client/src/components/tapestry-elements/items/webpage/index.tsx
+++ b/client/src/components/tapestry-elements/items/webpage/index.tsx
@@ -31,6 +31,7 @@ import {
   WebFrame,
   WebFrameSwitchProps,
 } from 'tapestry-core-client/src/components/tapestry/items/webpage/web-frame'
+import { useAsyncAction } from 'tapestry-core-client/src/components/lib/hooks/use-async-action'
 
 const checkedSources = new Map<string, boolean>()
 
@@ -78,6 +79,7 @@ function Webpage({ src, onLoad, ...props }: WebFrameSwitchProps) {
     <div className={styles.error}>
       <Icon icon="sentiment_very_dissatisfied" />
       <Text>{`Cannot frame ${src}`}</Text>
+      <Text>{`Switch to wayback machine version or convert to PDF.`}</Text>
     </div>
   ) : null
 }
@@ -98,6 +100,14 @@ export const WebpageItem = memo(({ id }: TapestryItemProps) => {
   const isEditMode = useTapestryData('interactionMode') === 'edit'
   const webSourceParams = parseWebSource(dto)
   const { webpageType } = webSourceParams
+
+  const {
+    trigger: convertToPDF,
+    loading: requestingConversion,
+    data: isConvertingToPdf,
+  } = useAsyncAction(({ signal }) =>
+    resource('items').update({ id }, { type: 'pdf' }, undefined, { signal }),
+  )
 
   const dispatch = useDispatch()
   const patch = ({ webpageType, data }: PatchSourceArgument) =>
@@ -184,6 +194,20 @@ export const WebpageItem = memo(({ id }: TapestryItemProps) => {
             },
             'separator',
             refreshButton,
+            'separator',
+            {
+              element:
+                requestingConversion || isConvertingToPdf ? (
+                  <LoadingSpinner style={{ alignSelf: 'center' }} size="16px" />
+                ) : (
+                  <IconButton
+                    icon="picture_as_pdf"
+                    aria-label="Convert to PDF"
+                    onClick={convertToPDF}
+                  />
+                ),
+              tooltip: { side: 'bottom', children: 'Convert to PDF' },
+            },
             'separator',
             ...controls,
           ]

--- a/server/src/resources/items.ts
+++ b/server/src/resources/items.ts
@@ -23,6 +23,7 @@ import { findWebSourceParser } from 'tapestry-core/src/web-sources/index.js'
 import { MEDIA_ITEM_TYPES } from 'tapestry-core/src/data-format/schemas/item.js'
 import { extractInternallyHostedS3Key } from '../services/s3-service.js'
 import { Path, WithOptional } from 'tapestry-core/src/type-utils.js'
+import { queue } from '../tasks/index.js'
 
 type ItemWithRequiredAssets = Prisma.ItemGetPayload<{
   include: { thumbnail: { include: { renditions: true } } }
@@ -96,6 +97,18 @@ async function resolveWebSource(item: ItemCreateDto | ItemUpdateDto) {
 
   item.source = webSourceParser.construct(webSourceParser.parse(item.source))
   item.webpageType = webSourceParser.webpageType
+}
+
+async function scheduleConvertToPdf(item: ItemWithAssets) {
+  await queue.add(
+    'convert-to-pdf',
+    { itemId: item.id },
+    {
+      removeOnComplete: true,
+      removeOnFail: true,
+      jobId: item.id,
+    },
+  )
 }
 
 async function processThumbnailUpdate(
@@ -204,7 +217,11 @@ export async function updateItems(
         const dbItem = await tx.item.findUniqueOrThrow({ where: { id } })
 
         if (dbItem.type !== update.type) {
-          throw new BadRequestError('Item type cannot be changed')
+          if (dbItem.type === 'webpage' && update.type === 'pdf') {
+            await scheduleConvertToPdf(dbItem)
+            return serialize('Item', dbItem)
+          }
+          throw new BadRequestError('This item type coversion is not supported')
         }
 
         if (isMediaItemUpdate(update) && update.source && dbItem.source !== update.source) {

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -60,6 +60,13 @@ export class DBSubscriber {
   async close() {
     return this.subscriber.close()
   }
+
+  static async fireNotification(notification: DBNotification) {
+    const dbSubscriber = new DBSubscriber()
+    await dbSubscriber.init()
+    await dbSubscriber.notify(notification)
+    await dbSubscriber.close()
+  }
 }
 
 export class Connection {

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -65,57 +65,59 @@ class SocketServer {
 
   private dbSubscriber?: Subscriber
 
-  async init(server: http.Server) {
-    const io = new Server<ClientToServerEvents, ServerToClientEvents, never, { userId: string }>(
-      server,
-      { path: SOCKET_PATH, cors: { origin: config.server.viewerUrl } },
-    )
-
-    io.use((socket, next) => {
-      const { token } = socket.handshake.auth
-      if (typeof token !== 'string') {
-        return next(new InvalidAccessTokenError())
-      }
-      try {
-        const { userId } = verifySessionJWT(token)
-        socket.data.userId = userId
-        next()
-      } catch (error) {
-        next(error as InvalidCredentialsError)
-      }
-    })
-
-    io.on('connection', (socket) => {
-      const connection = new Connection(socket)
-      this.connections.push(connection)
-
-      socket.on('subscribe', (e: SubscriptionEvent, params: unknown, callback: unknown) => {
-        // @ts-expect-error Hard to convince TS here
-        this.onSubscribe[e](connection, params, callback)
-      })
-
-      socket.on('rtc-signaling-message', (e) =>
-        this.notifyPeers(RTCSignalingMessageSchema.parse(e), e.tapestryId, socket.id),
+  async init(server?: http.Server) {
+    if (server) {
+      const io = new Server<ClientToServerEvents, ServerToClientEvents, never, { userId: string }>(
+        server,
+        { path: SOCKET_PATH, cors: { origin: config.server.viewerUrl } },
       )
 
-      socket.on('disconnect', () => {
-        this.connections
-          .find((c) => c.id === socket.id)
-          ?.subscriptions.forEach((s) => {
-            if (s.name === 'rtc-signaling-message') {
-              this.notifyPeers(
-                {
-                  type: 'disconnect',
-                  senderId: s.params.peerId,
-                },
-                s.params.tapestryId,
-                socket.id,
-              )
-            }
-          })
-        this.connections = this.connections.filter((c) => c.id !== socket.id)
+      io.use((socket, next) => {
+        const { token } = socket.handshake.auth
+        if (typeof token !== 'string') {
+          return next(new InvalidAccessTokenError())
+        }
+        try {
+          const { userId } = verifySessionJWT(token)
+          socket.data.userId = userId
+          next()
+        } catch (error) {
+          next(error as InvalidCredentialsError)
+        }
       })
-    })
+
+      io.on('connection', (socket) => {
+        const connection = new Connection(socket)
+        this.connections.push(connection)
+
+        socket.on('subscribe', (e: SubscriptionEvent, params: unknown, callback: unknown) => {
+          // @ts-expect-error Hard to convince TS here
+          this.onSubscribe[e](connection, params, callback)
+        })
+
+        socket.on('rtc-signaling-message', (e) =>
+          this.notifyPeers(RTCSignalingMessageSchema.parse(e), e.tapestryId, socket.id),
+        )
+
+        socket.on('disconnect', () => {
+          this.connections
+            .find((c) => c.id === socket.id)
+            ?.subscriptions.forEach((s) => {
+              if (s.name === 'rtc-signaling-message') {
+                this.notifyPeers(
+                  {
+                    type: 'disconnect',
+                    senderId: s.params.peerId,
+                  },
+                  s.params.tapestryId,
+                  socket.id,
+                )
+              }
+            })
+          this.connections = this.connections.filter((c) => c.id !== socket.id)
+        })
+      })
+    }
 
     this.dbSubscriber = await initSubscriber()
     this.dbSubscriber.notifications.on(DEFAULT_CHANNEL, async (payload) => {

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -30,20 +30,36 @@ import {
 } from 'tapestry-shared/src/data-transfer/rtc-signaling/types.js'
 
 const DEFAULT_CHANNEL = 'default'
+export class DBSubscriber {
+  private subscriber: Subscriber<{ [DEFAULT_CHANNEL]: DBNotification }>
 
-async function initSubscriber() {
-  const subscriber = createSubscriber({
-    connectionString: config.db.connectionString,
-    ssl: config.db.useSsl ? { rejectUnauthorized: false } : false,
-  })
-  await subscriber.connect()
-  await subscriber.listenTo(DEFAULT_CHANNEL)
+  constructor() {
+    this.subscriber = createSubscriber({
+      connectionString: config.db.connectionString,
+      ssl: config.db.useSsl ? { rejectUnauthorized: false } : false,
+    })
+  }
 
-  subscriber.events.on('error', (e) => {
-    console.error('Subscription error', e)
-  })
+  async init() {
+    await this.subscriber.connect()
+    await this.subscriber.listenTo(DEFAULT_CHANNEL)
 
-  return subscriber
+    this.subscriber.events.on('error', (e) => {
+      console.error('Subscription error', e)
+    })
+  }
+
+  onNotification(listener: (notification: DBNotification) => void) {
+    this.subscriber.notifications.on(DEFAULT_CHANNEL, listener)
+  }
+
+  async notify(notification: DBNotification) {
+    return this.subscriber.notify(DEFAULT_CHANNEL, notification)
+  }
+
+  async close() {
+    return this.subscriber.close()
+  }
 }
 
 export class Connection {
@@ -63,64 +79,63 @@ export class Connection {
 class SocketServer {
   private connections: Connection[] = []
 
-  private dbSubscriber?: Subscriber
+  private dbSubscriber?: DBSubscriber
 
-  async init(server?: http.Server) {
-    if (server) {
-      const io = new Server<ClientToServerEvents, ServerToClientEvents, never, { userId: string }>(
-        server,
-        { path: SOCKET_PATH, cors: { origin: config.server.viewerUrl } },
+  async init(server: http.Server) {
+    const io = new Server<ClientToServerEvents, ServerToClientEvents, never, { userId: string }>(
+      server,
+      { path: SOCKET_PATH, cors: { origin: config.server.viewerUrl } },
+    )
+
+    io.use((socket, next) => {
+      const { token } = socket.handshake.auth
+      if (typeof token !== 'string') {
+        return next(new InvalidAccessTokenError())
+      }
+      try {
+        const { userId } = verifySessionJWT(token)
+        socket.data.userId = userId
+        next()
+      } catch (error) {
+        next(error as InvalidCredentialsError)
+      }
+    })
+
+    io.on('connection', (socket) => {
+      const connection = new Connection(socket)
+      this.connections.push(connection)
+
+      socket.on('subscribe', (e: SubscriptionEvent, params: unknown, callback: unknown) => {
+        // @ts-expect-error Hard to convince TS here
+        this.onSubscribe[e](connection, params, callback)
+      })
+
+      socket.on('rtc-signaling-message', (e) =>
+        this.notifyPeers(RTCSignalingMessageSchema.parse(e), e.tapestryId, socket.id),
       )
 
-      io.use((socket, next) => {
-        const { token } = socket.handshake.auth
-        if (typeof token !== 'string') {
-          return next(new InvalidAccessTokenError())
-        }
-        try {
-          const { userId } = verifySessionJWT(token)
-          socket.data.userId = userId
-          next()
-        } catch (error) {
-          next(error as InvalidCredentialsError)
-        }
+      socket.on('disconnect', () => {
+        this.connections
+          .find((c) => c.id === socket.id)
+          ?.subscriptions.forEach((s) => {
+            if (s.name === 'rtc-signaling-message') {
+              this.notifyPeers(
+                {
+                  type: 'disconnect',
+                  senderId: s.params.peerId,
+                },
+                s.params.tapestryId,
+                socket.id,
+              )
+            }
+          })
+        this.connections = this.connections.filter((c) => c.id !== socket.id)
       })
+    })
 
-      io.on('connection', (socket) => {
-        const connection = new Connection(socket)
-        this.connections.push(connection)
-
-        socket.on('subscribe', (e: SubscriptionEvent, params: unknown, callback: unknown) => {
-          // @ts-expect-error Hard to convince TS here
-          this.onSubscribe[e](connection, params, callback)
-        })
-
-        socket.on('rtc-signaling-message', (e) =>
-          this.notifyPeers(RTCSignalingMessageSchema.parse(e), e.tapestryId, socket.id),
-        )
-
-        socket.on('disconnect', () => {
-          this.connections
-            .find((c) => c.id === socket.id)
-            ?.subscriptions.forEach((s) => {
-              if (s.name === 'rtc-signaling-message') {
-                this.notifyPeers(
-                  {
-                    type: 'disconnect',
-                    senderId: s.params.peerId,
-                  },
-                  s.params.tapestryId,
-                  socket.id,
-                )
-              }
-            })
-          this.connections = this.connections.filter((c) => c.id !== socket.id)
-        })
-      })
-    }
-
-    this.dbSubscriber = await initSubscriber()
-    this.dbSubscriber.notifications.on(DEFAULT_CHANNEL, async (payload) => {
+    this.dbSubscriber = new DBSubscriber()
+    await this.dbSubscriber.init()
+    this.dbSubscriber.onNotification(async (payload) => {
       const notification = DBNotificationSchema.parse(payload)
       for (const c of this.connections) {
         if (c.id === notification.socketId) {
@@ -307,7 +322,7 @@ class SocketServer {
 
   private async notify(notification: DBNotification) {
     try {
-      await this.dbSubscriber?.notify(DEFAULT_CHANNEL, notification)
+      await this.dbSubscriber?.notify(notification)
     } catch (error) {
       console.warn('Error while notifying', error)
       // This is intentionally swallowed, since we don't want to crash the server

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -68,14 +68,11 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
 
     await scheduleTapestryThumbnailGeneration(item.tapestryId)
 
-    const dbSubscriber = new DBSubscriber()
-    await dbSubscriber.init()
-    await dbSubscriber.notify({
+    await DBSubscriber.fireNotification({
       name: 'tapestry-updated',
       tapestryId: item.tapestryId,
       deletedIds: { items: [item.id] },
     })
-    await dbSubscriber.close()
   } catch (error) {
     console.error(`Error while converting item ${itemId} to pdf`, error)
   }

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -1,0 +1,77 @@
+import { PDFOptions } from 'puppeteer'
+import { JobTypeMap } from '.'
+import { prisma } from '../db'
+import { initWebpage, inNewBrowserPage, scheduleTapestryThumbnailGeneration } from './utils'
+import { s3Service, tapestryKey } from '../services/s3-service'
+import { socketServer } from '../socket'
+import { pick } from 'lodash-es'
+import { Item } from '@prisma/client'
+
+const CONVERT_ITEM_PROPS = [
+  'positionX',
+  'positionY',
+  'width',
+  'height',
+  'tapestryId',
+  'groupId',
+  'dropShadow',
+] satisfies (keyof Item)[]
+
+async function convertWebpageToPdf(url: string, options?: PDFOptions) {
+  let generator: ReturnType<typeof inNewBrowserPage<Uint8Array>> | undefined
+  try {
+    console.log(`Converting ${url} to pdf...`)
+    generator = inNewBrowserPage(async function* (page, context): AsyncGenerator<Uint8Array> {
+      await initWebpage(page, context, { url })
+      console.log('>  Converting to pdf...')
+      yield page.pdf(options)
+    })
+
+    const result = await generator.next()
+    if (result.done) throw new Error('Expected one value but got none!')
+
+    return result.value
+  } finally {
+    await generator?.return()
+  }
+}
+
+export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
+  try {
+    const item = await prisma.item.findUniqueOrThrow({
+      where: { id: itemId },
+    })
+
+    if (item.type !== 'webpage' || !item.source) {
+      throw new Error(`PDF convertion not supported for item type ${item.type}`)
+    }
+
+    const value = await convertWebpageToPdf(item.source, {
+      width: item.width,
+      height: item.height,
+    })
+
+    await prisma.$transaction(async (tx) => {
+      await tx.item.delete({ where: { id: item.id } })
+
+      const s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)
+      await tx.item.create({
+        data: {
+          ...pick(item, CONVERT_ITEM_PROPS),
+          type: 'pdf',
+          source: s3Key,
+          scheduledThumbnailProcessing: 'derive',
+        },
+      })
+      await s3Service.putObject(s3Key, value, 'application/pdf')
+    })
+
+    await scheduleTapestryThumbnailGeneration(item.tapestryId)
+    socketServer.notifyTapestryUpdate(
+      { deletedIds: { items: [item.id] }, tapestryId: item.tapestryId },
+      undefined,
+    )
+  } catch (error) {
+    console.error(`Error while converting item ${itemId} to pdf`, error)
+  }
+}

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -3,7 +3,7 @@ import { JobTypeMap } from '.'
 import { prisma } from '../db'
 import { initWebpage, inNewBrowserPage, scheduleTapestryThumbnailGeneration } from './utils'
 import { s3Service, tapestryKey } from '../services/s3-service'
-import { socketServer } from '../socket'
+import { DBSubscriber } from '../socket'
 import { pick } from 'lodash-es'
 import { Item } from '@prisma/client'
 
@@ -67,10 +67,15 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
     })
 
     await scheduleTapestryThumbnailGeneration(item.tapestryId)
-    socketServer.notifyTapestryUpdate(
-      { deletedIds: { items: [item.id] }, tapestryId: item.tapestryId },
-      undefined,
-    )
+
+    const dbSubscriber = new DBSubscriber()
+    await dbSubscriber.init()
+    await dbSubscriber.notify({
+      name: 'tapestry-updated',
+      tapestryId: item.tapestryId,
+      deletedIds: { items: [item.id] },
+    })
+    await dbSubscriber.close()
   } catch (error) {
     console.error(`Error while converting item ${itemId} to pdf`, error)
   }

--- a/server/src/tasks/index.ts
+++ b/server/src/tasks/index.ts
@@ -17,6 +17,9 @@ export interface JobTypeMap {
   'create-tapestry': {
     tapestryCreateJobId: string
   }
+  'convert-to-pdf': {
+    itemId: string
+  }
 }
 
 export type JobName = keyof JobTypeMap

--- a/server/src/tasks/thumbnail-generators/tapestry.ts
+++ b/server/src/tasks/thumbnail-generators/tapestry.ts
@@ -3,12 +3,12 @@ import { URL } from 'url'
 import { config } from '../../config.js'
 import { createJWT } from '../../auth/tokens.js'
 import { REFRESH_TOKEN_COOKIE_NAME } from '../../auth/index.js'
-import { initWebpage, inNewBrowserPage, WebpageConfig } from './webpage.js'
 import { ThumbnailRenditionOutput } from './index.js'
 import { generateThumbnail } from './image.js'
 import { Page, ScreenshotOptions } from 'puppeteer'
 import { Item } from '@prisma/client'
 import { innerFit } from 'tapestry-core/src/lib/geometry.js'
+import { initWebpage, inNewBrowserPage, WebpageConfig } from '../utils.js'
 
 const MAX_ITEM_SIZE = 2000
 

--- a/server/src/tasks/thumbnail-generators/webpage.ts
+++ b/server/src/tasks/thumbnail-generators/webpage.ts
@@ -1,77 +1,9 @@
 import axios from 'axios'
 import { OEmbed } from 'tapestry-core/src/oembed.js'
-import { Size } from 'tapestry-core/src/lib/geometry'
 import { WEB_SOURCE_PARSERS } from 'tapestry-core/src/web-sources/index.js'
 import { generateThumbnail } from './image'
-import puppeteer, { BrowserContext, Page, ScreenshotOptions } from 'puppeteer'
-import { config } from '../../config.js'
-import { downloadImageToArrayBuffer } from '../utils'
-
-// This is the user agent as if the browser was launched with { headless : false }.
-// Vimeo appears to have some sort of filtering (evidently only for public videos) based on the user agent.
-// When the puppeteer browser is launched with { headless: true } (the default) it automatically has "HeadlessChrome"
-// as part of its user agent, which causes Vimeo to block the requests
-const USER_AGENT =
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'
-
-export async function* inNewBrowserPage<T, R = void, N = void>(
-  perform: (page: Page, context: BrowserContext) => AsyncGenerator<T, R, N>,
-) {
-  const start = Date.now()
-  const browser = await puppeteer.launch({ args: config.worker.puppeteerArgs.split(',') })
-  const context = await browser.createBrowserContext()
-  const page = await context.newPage()
-  await page.setUserAgent({ userAgent: USER_AGENT })
-
-  try {
-    yield* perform(page, context)
-  } finally {
-    try {
-      await browser.close()
-    } catch (e) {
-      console.debug('Error while closing puppeteer browser context', e)
-    }
-    console.log(`Browser session completed in ${Date.now() - start}ms.`)
-  }
-}
-
-export interface WebpageConfig {
-  url: string
-  windowSize: Size
-  timeout?: number
-  setupContext?: (context: BrowserContext) => Promise<void>
-}
-
-export async function initWebpage(
-  page: Page,
-  context: BrowserContext,
-  { url, windowSize, setupContext, timeout }: WebpageConfig,
-) {
-  console.log('>  Setting up context...')
-  await setupContext?.(context)
-  console.log('>  Configuring viewport...')
-  await page.setViewport({ ...windowSize, deviceScaleFactor: 2 })
-  console.log(`>  Navigating to ${url}...`)
-  await page.goto(url, { timeout: 120_000 })
-  try {
-    console.log(`>  Waiting for network idle...`)
-    await page.waitForNetworkIdle({
-      idleTime: 3000,
-      concurrency: 0,
-      timeout: timeout ?? 60_000,
-    })
-    console.log(`>  Waiting for fonts to load...`)
-    // @ts-expect-error The following expression will be evaluated in the browser context
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-    await page.evaluate(() => document.fonts.ready)
-  } catch (error) {
-    console.warn(
-      'Error while waiting for the page to load before taking a screenshot. ' +
-        'Taking the screenshot anyway, but it may appear broken.',
-      error,
-    )
-  }
-}
+import { ScreenshotOptions } from 'puppeteer'
+import { downloadImageToArrayBuffer, initWebpage, inNewBrowserPage, WebpageConfig } from '../utils'
 
 async function takeScreenshot(site: WebpageConfig, options?: ScreenshotOptions) {
   let generator: ReturnType<typeof inNewBrowserPage<Uint8Array>> | undefined

--- a/server/src/tasks/utils.ts
+++ b/server/src/tasks/utils.ts
@@ -9,6 +9,9 @@ import { ItemType } from 'tapestry-core/src/data-format/schemas/item'
 import { queue } from '.'
 import { prisma } from '../db'
 import { config } from '../config'
+import puppeteer, { BrowserContext, Page } from 'puppeteer'
+import { Size } from 'tapestry-core/src/lib/geometry'
+import { WithOptional } from 'tapestry-core/src/type-utils'
 
 export interface DownloadOpts {
   timeoutMs?: number
@@ -128,5 +131,69 @@ export async function generateThumbnails({
 
   for (const id of new Set(items.map((item) => item.tapestryId))) {
     await scheduleTapestryThumbnailGeneration(id, { skipDelay: true })
+  }
+}
+
+// This is the user agent as if the browser was launched with { headless : false }.
+// Vimeo appears to have some sort of filtering (evidently only for public videos) based on the user agent.
+// When the puppeteer browser is launched with { headless: true } (the default) it automatically has "HeadlessChrome"
+// as part of its user agent, which causes Vimeo to block the requests
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'
+
+export async function* inNewBrowserPage<T, R = void, N = void>(
+  perform: (page: Page, context: BrowserContext) => AsyncGenerator<T, R, N>,
+) {
+  const start = Date.now()
+  const browser = await puppeteer.launch({ args: config.worker.puppeteerArgs.split(',') })
+  const context = await browser.createBrowserContext()
+  const page = await context.newPage()
+  await page.setUserAgent({ userAgent: USER_AGENT })
+
+  try {
+    yield* perform(page, context)
+  } finally {
+    try {
+      await browser.close()
+    } catch (e) {
+      console.debug('Error while closing puppeteer browser context', e)
+    }
+    console.log(`Browser session completed in ${Date.now() - start}ms.`)
+  }
+}
+
+export interface WebpageConfig {
+  url: string
+  windowSize: Size
+  timeout?: number
+  setupContext?: (context: BrowserContext) => Promise<void>
+}
+
+export async function initWebpage(
+  page: Page,
+  context: BrowserContext,
+  { url, windowSize, setupContext, timeout }: WithOptional<WebpageConfig, 'windowSize'>,
+) {
+  console.log('>  Setting up context...')
+  await setupContext?.(context)
+  if (windowSize) {
+    console.log('>  Configuring viewport...')
+    await page.setViewport({ ...windowSize, deviceScaleFactor: 2 })
+  }
+  console.log(`>  Navigating to ${url}...`)
+  await page.goto(url, { timeout: 120_000 })
+  try {
+    console.log(`>  Waiting for network idle...`)
+    await page.waitForNetworkIdle({
+      idleTime: 3000,
+      concurrency: 0,
+      timeout: timeout ?? 60_000,
+    })
+    console.log(`>  Waiting for fonts to load...`)
+    // @ts-expect-error The following expression will be evaluated in the browser context
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    await page.evaluate(() => document.fonts.ready)
+  } catch (error) {
+    console.warn('Error while waiting for the page to load. Proceeding anyway', error)
   }
 }

--- a/server/src/tasks/worker.ts
+++ b/server/src/tasks/worker.ts
@@ -3,6 +3,8 @@ import { BULLMQ_REDIS_BASE_OPTIONS, JobName, JobTypeMap, QUEUE_NAME } from './in
 import { generateTapestryThumbnails } from './generate-tapestry-thumbnails.js'
 import { s3Cleanup } from './s3-cleanup.js'
 import { createTapestry } from './create-tapestry.js'
+import { convertToPdf } from './convert-to-pdf.js'
+import { socketServer } from '../socket/index.js'
 
 async function processTask(job: Job<JobTypeMap[JobName], void, JobName>) {
   switch (job.name) {
@@ -12,9 +14,12 @@ async function processTask(job: Job<JobTypeMap[JobName], void, JobName>) {
       return s3Cleanup()
     case 'create-tapestry':
       return createTapestry(job.data as JobTypeMap['create-tapestry'])
+    case 'convert-to-pdf':
+      return convertToPdf(job.data as JobTypeMap['convert-to-pdf'])
   }
 }
 
+void socketServer.init()
 const worker = new Worker(QUEUE_NAME, processTask, BULLMQ_REDIS_BASE_OPTIONS)
 
 worker.on('ready', () => {

--- a/server/src/tasks/worker.ts
+++ b/server/src/tasks/worker.ts
@@ -4,7 +4,6 @@ import { generateTapestryThumbnails } from './generate-tapestry-thumbnails.js'
 import { s3Cleanup } from './s3-cleanup.js'
 import { createTapestry } from './create-tapestry.js'
 import { convertToPdf } from './convert-to-pdf.js'
-import { socketServer } from '../socket/index.js'
 
 async function processTask(job: Job<JobTypeMap[JobName], void, JobName>) {
   switch (job.name) {
@@ -19,7 +18,6 @@ async function processTask(job: Job<JobTypeMap[JobName], void, JobName>) {
   }
 }
 
-void socketServer.init()
 const worker = new Worker(QUEUE_NAME, processTask, BULLMQ_REDIS_BASE_OPTIONS)
 
 worker.on('ready', () => {


### PR DESCRIPTION
1. Created a convert to PDF worker task, which uses puppeteer to convert webpages to PDF
2. Added a button to the webpage toolbar for conversion to PDF. Currently an item update with data { type: 'pdf' } is sent to the server, but we could implement a separate endpoint for conversions.
3. The webpage item gets deleted and replaced by the newly created PDF item.
4. The worker now uses the SocketServer in order to send the tapestry update notification.