### PR TITLE
Fix stopping playback after focus

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,4 +1,4 @@
-import { NullishInt } from 'tapestry-core/src/data-format/schemas/common'
+import { OptionalInt } from 'tapestry-core/src/data-format/schemas/common'
 import { deepFreeze } from 'tapestry-core/src/utils'
 import { treeifyError, z } from 'zod/v4'
 
@@ -9,9 +9,9 @@ const parsedConfig = deepFreeze(
       VITE_AUTH_PROVIDER: z.enum(['ia', 'google']).catch('google'),
       VITE_GOOGLE_CLIENT_ID: z.string(),
       VITE_BUG_REPORT_FORM_URL: z.string(),
-      VITE_AI_CHAT_EXPIRES_IN: NullishInt(3600), // default: one hour
-      VITE_WEBPAGE_LOADER_TIMEOUT: NullishInt(3, (schema) => schema.nonnegative()),
-      VITE_WBM_SNAPSHOT_POLLING_PERIOD: NullishInt(600), // default: ten minutes
+      VITE_AI_CHAT_EXPIRES_IN: OptionalInt(3600), // default: one hour
+      VITE_WEBPAGE_LOADER_TIMEOUT: OptionalInt(3, (schema) => schema.nonnegative()),
+      VITE_WBM_SNAPSHOT_POLLING_PERIOD: OptionalInt(600), // default: ten minutes
       VITE_STUN_SERVER: z.string(),
       VITE_SENTRY_DSN: z.string().default(''),
     })

--- a/core-client/src/components/tapestry/hooks/use-media-params.ts
+++ b/core-client/src/components/tapestry/hooks/use-media-params.ts
@@ -1,5 +1,5 @@
 import { useSearchParams } from 'react-router'
-import { Id, NullishInt } from 'tapestry-core/src/data-format/schemas/common'
+import { Id, OptionalInt } from 'tapestry-core/src/data-format/schemas/common'
 
 export interface MediaParams {
   startTime: number | undefined | null
@@ -16,8 +16,8 @@ export function useMediaParams(id: Id): MediaParams {
   const autoplay = searchParams.get('autoplay')
 
   return {
-    startTime: NullishInt().safeParse(searchParams.get('startTime') ?? undefined).data,
-    stopTime: NullishInt().safeParse(searchParams.get('stopTime') ?? undefined).data,
+    startTime: OptionalInt().safeParse(searchParams.get('startTime') ?? undefined).data,
+    stopTime: OptionalInt().safeParse(searchParams.get('stopTime') ?? undefined).data,
     autoplay: autoplay === 'true' ? true : autoplay === 'false' ? false : undefined,
   }
 }

--- a/core-client/src/components/tapestry/hooks/use-media-params.ts
+++ b/core-client/src/components/tapestry/hooks/use-media-params.ts
@@ -16,8 +16,8 @@ export function useMediaParams(id: Id): MediaParams {
   const autoplay = searchParams.get('autoplay')
 
   return {
-    startTime: NullishInt().safeParse(searchParams.get('startTime')).data,
-    stopTime: NullishInt().safeParse(searchParams.get('stopTime')).data,
+    startTime: NullishInt().safeParse(searchParams.get('startTime') ?? undefined).data,
+    stopTime: NullishInt().safeParse(searchParams.get('stopTime') ?? undefined).data,
     autoplay: autoplay === 'true' ? true : autoplay === 'false' ? false : undefined,
   }
 }

--- a/core-client/src/components/tapestry/hooks/use-start-page.ts
+++ b/core-client/src/components/tapestry/hooks/use-start-page.ts
@@ -7,7 +7,7 @@ export function useStartPage(id: Id) {
     return undefined
   }
 
-  const page = NullishInt().safeParse(searchParams.get('page')).data
+  const page = NullishInt().safeParse(searchParams.get('page') ?? undefined).data
 
   return page ? page - 1 : page
 }

--- a/core-client/src/components/tapestry/hooks/use-start-page.ts
+++ b/core-client/src/components/tapestry/hooks/use-start-page.ts
@@ -1,5 +1,5 @@
 import { useSearchParams } from 'react-router'
-import { Id, NullishInt } from 'tapestry-core/src/data-format/schemas/common'
+import { Id, OptionalInt } from 'tapestry-core/src/data-format/schemas/common'
 
 export function useStartPage(id: Id) {
   const [searchParams] = useSearchParams()
@@ -7,7 +7,7 @@ export function useStartPage(id: Id) {
     return undefined
   }
 
-  const page = NullishInt().safeParse(searchParams.get('page') ?? undefined).data
+  const page = OptionalInt().safeParse(searchParams.get('page') ?? undefined).data
 
   return page ? page - 1 : page
 }

--- a/core/src/data-format/schemas/common.ts
+++ b/core/src/data-format/schemas/common.ts
@@ -36,12 +36,12 @@ type OptionalNumber = ZodOptional<
 >
 
 type SchemaTransformer = (schema: ZodCoercedNumber<unknown>) => ZodCoercedNumber<unknown>
-export function NullishInt(
+export function OptionalInt(
   defaultValue: number,
   apply?: SchemaTransformer,
 ): ZodDefault<OptionalNumber>
-export function NullishInt(defaultValue?: number, apply?: SchemaTransformer): OptionalNumber
-export function NullishInt(
+export function OptionalInt(defaultValue?: number, apply?: SchemaTransformer): OptionalNumber
+export function OptionalInt(
   defaultValue?: number,
   apply?: SchemaTransformer,
 ): ZodDefault<OptionalNumber> | OptionalNumber {
@@ -57,7 +57,7 @@ export function NullishInt(
 }
 
 export const Port = (defaultPort: number) =>
-  NullishInt(defaultPort, (schema) => schema.min(0).max(65535))
+  OptionalInt(defaultPort, (schema) => schema.min(0).max(65535))
 
 export type HexColor = z.infer<typeof HexColorSchema>
 export type Point = z.infer<typeof PointSchema>

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,7 +1,7 @@
 import '@dotenvx/dotenvx/config'
 import z from 'zod/v4'
 import { deepFreeze } from 'tapestry-core/src/utils.js'
-import { NullishInt, Port } from 'tapestry-core/src/data-format/schemas/common'
+import { OptionalInt, Port } from 'tapestry-core/src/data-format/schemas/common'
 
 const checkTrue = z
   .string()
@@ -28,10 +28,10 @@ export const config = deepFreeze(
       GOOGLE_CLIENT_ID: z.string().default(''),
       IA_ACCOUNT_ID: z.string().default(''),
       IA_SECRET: z.string().default(''),
-      WBM_RESPONSE_CACHE_DURATION: NullishInt(3600), // one hour in seconds
-      WBM_EMPTY_RESPONSE_CACHE_DURATION: NullishInt(120),
-      ASSET_READ_URL_EXPIRES_IN: NullishInt(604_800), // on week in seconds
-      ASSET_READ_URL_VALIDATION_EXPIRES_IN: NullishInt(600),
+      WBM_RESPONSE_CACHE_DURATION: OptionalInt(3600), // one hour in seconds
+      WBM_EMPTY_RESPONSE_CACHE_DURATION: OptionalInt(120),
+      ASSET_READ_URL_EXPIRES_IN: OptionalInt(604_800), // on week in seconds
+      ASSET_READ_URL_VALIDATION_EXPIRES_IN: OptionalInt(600),
       EXTERNAL_SERVER_URL: z.string(),
       VIEWER_URL: z.string(),
       SECURE_COOKIE: z
@@ -58,10 +58,10 @@ export const config = deepFreeze(
       // Worker
       PUPPETEER_ARGS: z.string().default(''),
       S3_CLEAN_UP_CRON_PATTERN: z.string().default('0 0 * * *'),
-      TAPESTRY_THUMBNAIL_GENERATION_DELAY: NullishInt(150_000),
+      TAPESTRY_THUMBNAIL_GENERATION_DELAY: OptionalInt(150_000),
       // 5 minute timeout may look too long but some larger tapestries with a lot of iframes load slowly
       // so we better wait for a while in order to take a nicer screenshot.
-      TAPESTRY_THUMBNAIL_GENERATION_TIMEOUT: NullishInt(300_000),
+      TAPESTRY_THUMBNAIL_GENERATION_TIMEOUT: OptionalInt(300_000),
 
       // Queue monitoring
       JOBS_ADMIN_NAME: z.string().nullish(),


### PR DESCRIPTION
z.coerce.number used in NullishInt converts null to 0, and searchParams.get('...') returns null when the param is missing, however, in that case the parsed value should be undefined.