### PR TITLE
Remove zod schemas from render and smoothen continuous zoom

### DIFF
--- a/core-client/src/stage/renderer/group-background-renderer.ts
+++ b/core-client/src/stage/renderer/group-background-renderer.ts
@@ -12,7 +12,7 @@ import { idMapToArray } from 'tapestry-core/src/utils'
 import { drawDashedPolyline, roundedRectPolyline } from '../../lib/pixi'
 import { getOpaqueColor, LiteralColor } from '../../theme/types'
 import { Point, Rectangle, Size } from 'tapestry-core/src/lib/geometry'
-import { clamp } from 'lodash-es'
+import { clamp, throttle } from 'lodash-es'
 import { ThemeName, THEMES } from '../../theme/themes'
 import { TapestryElementRenderer } from './tapestry-element-renderer'
 import { roundToPrecision } from 'tapestry-core/src/lib/algebra'
@@ -35,6 +35,12 @@ export class GroupBackgroundRenderer<G extends GroupViewModel> extends TapestryE
 > {
   private background = new Graphics({ eventMode: 'static' })
   private border = new Graphics({ eventMode: 'none' })
+  private computeBorderScale = throttle(
+    (store: Store<TapestryViewModel>) =>
+      computeRestrictedScale(store.get('viewport'), idMapToArray(store.get('items'))) /
+      store.get('viewport.transform.scale'),
+    100,
+  )
 
   constructor(store: Store<TapestryViewModel>, stage: TapestryStage, viewModel: G) {
     super(store, stage, viewModel)
@@ -51,9 +57,7 @@ export class GroupBackgroundRenderer<G extends GroupViewModel> extends TapestryE
     const bounds = getBoundingRectangle(groupMembers).expand(MULTISELECT_RECTANGLE_PADDING)
     const backgroundColor = (hasBackground && color) || null
     const borderColor = hasBorder && color ? getOpaqueColor(color) : null
-    const scale = store.get('viewport.transform.scale')
-    const borderScale =
-      computeRestrictedScale(store.get('viewport'), idMapToArray(store.get('items'))) / scale
+    const borderScale = this.computeBorderScale(store)
 
     return {
       origin: bounds.position,

--- a/core-client/src/view-model/store-commands/viewport.ts
+++ b/core-client/src/view-model/store-commands/viewport.ts
@@ -221,7 +221,7 @@ export function zoomOut(continuous = false): StoreMutationCommand<TapestryViewMo
     const scale = viewport.transform.scale
     const minScale = getMinScale(viewport, idMapToArray(items))
     const { zoomStep, animate } = getZoomParameters(scale, minScale, continuous)
-    store.dispatch(transformViewport(zoomToCenter(store.get(), -zoomStep), animate))
+    store.dispatch(transformViewport(zoomToCenter(store.get(), zoomStep), animate))
     if (continuous) {
       continuousZoom = 'ZOOM-OUT'
       stopContinuosZoom()

--- a/core-client/src/view-model/store-commands/viewport.ts
+++ b/core-client/src/view-model/store-commands/viewport.ts
@@ -1,6 +1,6 @@
-import { Tween, Easing } from '@tweenjs/tween.js'
+import { Tween } from '@tweenjs/tween.js'
 import { AnimationOptions, tween } from '../tweening.js'
-import { TapestryViewModel, ZOOM_STEP, MAX_INITIAL_SCALE, MAX_SCALE } from '../index.js'
+import { TapestryViewModel, MAX_INITIAL_SCALE, MAX_SCALE } from '../index.js'
 import {
   LinearTransform,
   Vector,
@@ -23,13 +23,13 @@ import {
   getTranslationRange,
   getMinScale,
   getGroupMembers,
+  getZoomParameters,
 } from '../utils.js'
 import { idMapToArray, pickById } from 'tapestry-core/src/utils.js'
 import {
   cubicBezierPoly,
   Exponent,
   integrate,
-  log,
   Polynomial,
   RungeKutta4,
 } from 'tapestry-core/src/lib/algebra.js'
@@ -37,7 +37,7 @@ import { clamp, debounce } from 'lodash-es'
 import { selectItems, setInteractiveElement } from './tapestry.js'
 import { PresentationStep } from 'tapestry-core/src/data-format/schemas/presentation-step.js'
 
-const CONTINUOUS_ZOOM_SPEED = 3
+export const CONTINUOUS_ZOOM_SPEED = 3
 const ELEMENT_TOOLBAR_PADDING = 65
 
 let zoomAnimation: Tween | undefined = undefined
@@ -202,14 +202,7 @@ export function zoomIn(continuous = false): StoreMutationCommand<TapestryViewMod
       return
     }
     const scale = store.get('viewport.transform.scale')
-    const zoomStep = continuous ? Math.log(MAX_SCALE / scale) : ZOOM_STEP
-    const animate = continuous
-      ? {
-          easing: Easing.Linear.None,
-          duration: log(CONTINUOUS_ZOOM_SPEED, MAX_SCALE / scale),
-          zoomEffect: 'exponential' as const,
-        }
-      : true
+    const { zoomStep, animate } = getZoomParameters(scale, MAX_SCALE, continuous)
     store.dispatch(transformViewport(zoomToCenter(store.get(), zoomStep), animate))
     if (continuous) {
       continuousZoom = 'ZOOM-IN'
@@ -227,14 +220,7 @@ export function zoomOut(continuous = false): StoreMutationCommand<TapestryViewMo
     const { viewport, items } = store.get(['viewport', 'items'])
     const scale = viewport.transform.scale
     const minScale = getMinScale(viewport, idMapToArray(items))
-    const zoomStep = continuous ? Math.log(scale / minScale) : ZOOM_STEP
-    const animate = continuous
-      ? {
-          easing: Easing.Linear.None,
-          duration: log(CONTINUOUS_ZOOM_SPEED, scale / minScale),
-          zoomEffect: 'exponential' as const,
-        }
-      : true
+    const { zoomStep, animate } = getZoomParameters(scale, minScale, continuous)
     store.dispatch(transformViewport(zoomToCenter(store.get(), -zoomStep), animate))
     if (continuous) {
       continuousZoom = 'ZOOM-OUT'

--- a/core-client/src/view-model/store-commands/viewport.ts
+++ b/core-client/src/view-model/store-commands/viewport.ts
@@ -27,24 +27,29 @@ import {
 import { idMapToArray, pickById } from 'tapestry-core/src/utils.js'
 import {
   cubicBezierPoly,
+  Exponent,
   integrate,
+  log,
   Polynomial,
   RungeKutta4,
 } from 'tapestry-core/src/lib/algebra.js'
-import { clamp } from 'lodash-es'
+import { clamp, debounce } from 'lodash-es'
 import { selectItems, setInteractiveElement } from './tapestry.js'
 import { PresentationStep } from 'tapestry-core/src/data-format/schemas/presentation-step.js'
 
-const CONTINUOUS_ZOOM_STEP = 0.15
-const CONTINUOUS_ZOOM_ANIMATION_OPTIONS: AnimationOptions = {
-  easing: Easing.Linear.None,
-  duration: 0.1,
-}
+const CONTINUOUS_ZOOM_SPEED = 3
 const ELEMENT_TOOLBAR_PADDING = 65
 
 let zoomAnimation: Tween | undefined = undefined
+let continuousZoom: 'ZOOM-IN' | 'ZOOM-OUT' | null = null
+const stopContinuosZoom = debounce(() => {
+  if (continuousZoom !== null) {
+    zoomAnimation?.stop()
+    continuousZoom = null
+  }
+}, 100)
 
-export type AnimationEffect = 'linear' | 'bounce'
+export type AnimationEffect = 'linear' | 'bounce' | 'exponential'
 
 export interface ViewportAnimationOptions extends AnimationOptions {
   zoomEffect?: AnimationEffect
@@ -77,6 +82,7 @@ export function transformViewport(
       })
     }
 
+    continuousZoom = null
     zoomAnimation?.stop()
     if (animate) {
       const zoomEffect =
@@ -88,12 +94,16 @@ export function transformViewport(
       const zoomPath =
         zoomEffect === 'linear'
           ? new Polynomial([fromScale, toScale - fromScale])
-          : cubicBezierPoly([
-              fromScale,
-              Math.max(0, fromScale / 1.1),
-              Math.max(0, toScale / 1.1),
-              toScale,
-            ])
+          : zoomEffect === 'exponential'
+            ? new Exponent(toScale / fromScale).shifted(
+                Math.log(fromScale) / Math.log(toScale / fromScale),
+              )
+            : cubicBezierPoly([
+                fromScale,
+                Math.max(0, fromScale / 1.1),
+                Math.max(0, toScale / 1.1),
+                toScale,
+              ])
 
       // The goal here is to "move" (i.e. translate) the viewport at a constant perceived velocity. The perceived
       // translation velocity depends on the zoom level. If we want to move, say, 10 tapestry pixels at zoom level
@@ -112,7 +122,7 @@ export function transformViewport(
         { progress: 0 },
         { progress: 1 },
         ({ progress }) => {
-          const newScale = zoomPath.valueAt(progress)
+          const newScale = progress === 1 ? toScale : zoomPath.valueAt(progress)
           let newTranslation: Vector
           if (zoomEffect === 'linear') {
             // Preserving the translation velocity doesn't look very good for linear transitions, so here we apply
@@ -130,7 +140,7 @@ export function transformViewport(
               neg(mul(translationProgress * newScale, absoluteTranslation)),
             )
           }
-
+          
           updateViewport({ scale: newScale, translation: newTranslation })
         },
         typeof animate === 'object' ? animate : {},
@@ -187,17 +197,49 @@ export function resizeViewport(size: Size): StoreMutationCommand<TapestryViewMod
 
 export function zoomIn(continuous = false): StoreMutationCommand<TapestryViewModel> {
   return (_, { store }) => {
-    const zoomStep = continuous ? CONTINUOUS_ZOOM_STEP : ZOOM_STEP
-    const animate = continuous ? CONTINUOUS_ZOOM_ANIMATION_OPTIONS : true
+    if (continuous && continuousZoom === 'ZOOM-IN') {
+      stopContinuosZoom()
+      return
+    }
+    const scale = store.get('viewport.transform.scale')
+    const zoomStep = continuous ? Math.log(MAX_SCALE / scale) : ZOOM_STEP
+    const animate = continuous
+      ? {
+          easing: Easing.Linear.None,
+          duration: log(CONTINUOUS_ZOOM_SPEED, MAX_SCALE / scale),
+          zoomEffect: 'exponential' as const,
+        }
+      : true
     store.dispatch(transformViewport(zoomToCenter(store.get(), zoomStep), animate))
+    if (continuous) {
+      continuousZoom = 'ZOOM-IN'
+      stopContinuosZoom()
+    }
   }
 }
 
 export function zoomOut(continuous = false): StoreMutationCommand<TapestryViewModel> {
   return (_, { store }) => {
-    const zoomStep = continuous ? CONTINUOUS_ZOOM_STEP : ZOOM_STEP
-    const animate = continuous ? CONTINUOUS_ZOOM_ANIMATION_OPTIONS : true
+    if (continuous && continuousZoom === 'ZOOM-OUT') {
+      stopContinuosZoom()
+      return
+    }
+    const { viewport, items } = store.get(['viewport', 'items'])
+    const scale = viewport.transform.scale
+    const minScale = getMinScale(viewport, idMapToArray(items))
+    const zoomStep = continuous ? Math.log(scale / minScale) : ZOOM_STEP
+    const animate = continuous
+      ? {
+          easing: Easing.Linear.None,
+          duration: log(CONTINUOUS_ZOOM_SPEED, scale / minScale),
+          zoomEffect: 'exponential' as const,
+        }
+      : true
     store.dispatch(transformViewport(zoomToCenter(store.get(), -zoomStep), animate))
+    if (continuous) {
+      continuousZoom = 'ZOOM-OUT'
+      stopContinuosZoom()
+    }
   }
 }
 

--- a/core-client/src/view-model/store-commands/viewport.ts
+++ b/core-client/src/view-model/store-commands/viewport.ts
@@ -140,7 +140,7 @@ export function transformViewport(
               neg(mul(translationProgress * newScale, absoluteTranslation)),
             )
           }
-          
+
           updateViewport({ scale: newScale, translation: newTranslation })
         },
         typeof animate === 'object' ? animate : {},

--- a/core-client/src/view-model/utils.ts
+++ b/core-client/src/view-model/utils.ts
@@ -39,6 +39,7 @@ import {
   IdMap,
   idMapToArray,
   isItem,
+  isRel,
 } from 'tapestry-core/src/utils.js'
 import { Range } from 'tapestry-core/src/lib/algebra.js'
 import { ImageAsset, Item, ItemType } from 'tapestry-core/src/data-format/schemas/item.js'
@@ -90,27 +91,14 @@ export function isRelViewModel<T extends RelViewModel = RelViewModel>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj?: Record<string, any>,
 ): obj is T {
-  return (
-    !!obj &&
-    typeof obj.dto === 'object' &&
-    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-    typeof obj.dto.id === 'string' &&
-    typeof obj.dto.from === 'object' &&
-    typeof obj.dto.to === 'object'
-  )
+  return !!obj && isRel(obj.dto)
 }
 
 export function isItemViewModel<T extends ItemViewModel = ItemViewModel>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj?: Record<string, any>,
 ): obj is T {
-  return (
-    !!obj &&
-    typeof obj.dto === 'object' &&
-    typeof obj.dto.id === 'string' &&
-    typeof obj.dto.type === 'string'
-    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-  )
+  return !!obj && isItem(obj.dto)
 }
 
 export function getType(viewModel: RelViewModel): 'rel'

--- a/core-client/src/view-model/utils.ts
+++ b/core-client/src/view-model/utils.ts
@@ -31,6 +31,7 @@ import {
   Selection,
   PresentationStepViewModel,
   GroupViewModel,
+  ZOOM_STEP,
 } from './index.js'
 import { THEMES } from '../theme/themes.js'
 import {
@@ -41,12 +42,14 @@ import {
   isItem,
   isRel,
 } from 'tapestry-core/src/utils.js'
-import { Range } from 'tapestry-core/src/lib/algebra.js'
+import { log, Range } from 'tapestry-core/src/lib/algebra.js'
 import { ImageAsset, Item, ItemType } from 'tapestry-core/src/data-format/schemas/item.js'
 import { PresentationStep } from 'tapestry-core/src/data-format/schemas/presentation-step.js'
 import { Tapestry, TapestryElement } from 'tapestry-core/src/data-format/schemas/tapestry.js'
 import { isMobile } from '../lib/user-agent.js'
 import { Rel } from 'tapestry-core/src/data-format/schemas/rel.js'
+import { Easing } from '@tweenjs/tween.js'
+import { CONTINUOUS_ZOOM_SPEED } from './store-commands/viewport.js'
 
 const CONTENT_FIT_PADDING = 16
 
@@ -382,4 +385,19 @@ export function isBlobURL(str: string) {
 export function getPrimaryThumbnail(itemOrThumbnail: Item | ImageAsset | undefined | null) {
   const thumbnail = isItem(itemOrThumbnail) ? itemOrThumbnail.thumbnail : itemOrThumbnail
   return thumbnail?.renditions.find((r) => r.isPrimary)?.source
+}
+
+export function getZoomParameters(fromScale: number, toScale: number, continuous: boolean) {
+  return {
+    zoomStep: continuous
+      ? Math.log(toScale / fromScale)
+      : ZOOM_STEP * Math.sign(toScale - fromScale),
+    animate: continuous
+      ? {
+          easing: Easing.Linear.None,
+          duration: Math.abs(log(CONTINUOUS_ZOOM_SPEED, fromScale / toScale)),
+          zoomEffect: 'exponential' as const,
+        }
+      : true,
+  }
 }

--- a/core/src/data-format/schemas/item.ts
+++ b/core/src/data-format/schemas/item.ts
@@ -159,6 +159,8 @@ export const ItemSchema = z
       'Items are the main building blocks of tapestries.',
   )
 
+export const ITEM_TYPES: (string | undefined)[] = ItemSchema.options.map((o) => o.shape.type.value)
+
 export type ImageAsset = z.infer<typeof ImageAssetSchema>
 export type ImageAssetRendition = z.infer<typeof ImageAssetRenditionSchema>
 export type TextItem = z.infer<typeof TextItemSchema>

--- a/core/src/lib/algebra.ts
+++ b/core/src/lib/algebra.ts
@@ -5,8 +5,33 @@ export interface Range {
   max: number
 }
 
-export class Polynomial {
-  constructor(private coeffs: number[]) {}
+export class Function {
+  constructor(public valueAt: (x: number) => number) {}
+
+  shifted(y: number): Function {
+    return new Function((x) => this.valueAt(x + y))
+  }
+}
+
+export class Exponent extends Function {
+  constructor(base: number) {
+    super((x) => base ** x)
+  }
+}
+export class Polynomial extends Function {
+  constructor(private coeffs: number[]) {
+    super((x: number) => {
+      let xPower = 1
+      let sum = 0
+      for (const coeff of this.coeffs) {
+        if (Math.abs(coeff) > EPS) {
+          sum += coeff * xPower
+        }
+        xPower *= x
+      }
+      return sum
+    })
+  }
 
   get degree() {
     return Math.max(
@@ -17,18 +42,6 @@ export class Polynomial {
 
   coeffForDegree(degree: number) {
     return this.coeffs[degree] ?? 0
-  }
-
-  valueAt(x: number) {
-    let xPower = 1
-    let sum = 0
-    for (const coeff of this.coeffs) {
-      if (Math.abs(coeff) > EPS) {
-        sum += coeff * xPower
-      }
-      xPower *= x
-    }
-    return sum
   }
 
   derivative() {

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -1,8 +1,8 @@
 import { compact, fromPairs, isEmpty, set, zip } from 'lodash-es'
 import { Id, Identifiable } from './data-format/schemas/common.js'
-import { Item, ItemSchema, MediaItem, MediaItemSchema } from './data-format/schemas/item.js'
+import { Item, MediaItem } from './data-format/schemas/item.js'
 import { PresentationStep } from './data-format/schemas/presentation-step.js'
-import { Rel, RelSchema } from './data-format/schemas/rel.js'
+import { Rel } from './data-format/schemas/rel.js'
 import mime from 'mime'
 
 export function isHTTPURL(str: string | null | undefined): str is `http${string}` {
@@ -17,16 +17,26 @@ export function isHTTPURL(str: string | null | undefined): str is `http${string}
   }
 }
 
+export function isObject(obj: unknown): obj is Record<string, unknown> {
+  return !!obj && typeof obj === 'object'
+}
+
 export function isItem(obj: unknown): obj is Item {
-  return ItemSchema.safeParse(obj).success
+  return (
+    isObject(obj) &&
+    typeof obj.id === 'string' &&
+    typeof obj.type === 'string' &&
+    isObject(obj.position) &&
+    isObject(obj.size)
+  )
 }
 
 export function isRel(obj: unknown): obj is Rel {
-  return RelSchema.safeParse(obj).success
+  return isObject(obj) && typeof obj.id === 'string' && isObject(obj.from) && isObject(obj.to)
 }
 
 export function isMediaItem(item: unknown): item is MediaItem {
-  return MediaItemSchema.safeParse(item).success
+  return isObject(item) && typeof item.source === 'string' && isItem(item)
 }
 
 export function fileExtension(name: string): [string, string | undefined] {

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -1,6 +1,6 @@
 import { compact, fromPairs, isEmpty, set, zip } from 'lodash-es'
 import { Id, Identifiable } from './data-format/schemas/common.js'
-import { Item, MediaItem } from './data-format/schemas/item.js'
+import { Item, ITEM_TYPES, MEDIA_ITEM_TYPES, MediaItem } from './data-format/schemas/item.js'
 import { PresentationStep } from './data-format/schemas/presentation-step.js'
 import { Rel } from './data-format/schemas/rel.js'
 import mime from 'mime'
@@ -26,6 +26,7 @@ export function isItem(obj: unknown): obj is Item {
     isObject(obj) &&
     typeof obj.id === 'string' &&
     typeof obj.type === 'string' &&
+    ITEM_TYPES.includes(obj.type) &&
     isObject(obj.position) &&
     isObject(obj.size)
   )
@@ -36,7 +37,7 @@ export function isRel(obj: unknown): obj is Rel {
 }
 
 export function isMediaItem(item: unknown): item is MediaItem {
-  return isObject(item) && typeof item.source === 'string' && isItem(item)
+  return isItem(item) && MEDIA_ITEM_TYPES.includes(item.type)
 }
 
 export function fileExtension(name: string): [string, string | undefined] {


### PR DESCRIPTION
The computeRestricetedScale function validated all items through zod schemas and worsened render performance. Even after removing zod schema validation, the function is throttled for optimal results. 
The rate of events fired when pressing +/- keys for continuous zoom was too fast, which caused the animation to constantly stop and start again with new parameters. That is why I created a new single exponential animation which plays only once while the events are being fired until activity ceases for at least 0.1s.