### PR TITLE
Animate tapestry actions

### DIFF
--- a/client/src/components/side-pane/index.tsx
+++ b/client/src/components/side-pane/index.tsx
@@ -18,6 +18,7 @@ import {
 } from 'tapestry-core-client/src/components/tapestry/help-pane/guide-pane'
 import { thru } from 'lodash-es'
 import {
+  Action,
   ActionsSection,
   CustomKeys,
   DEFAULT_ACTIONS,
@@ -40,17 +41,25 @@ const EDITOR_GUIDE: GuideSection[] = [
   }),
 ]
 
+const commonActions: Record<string, Action[]> = {
+  'General shortcuts': [{ name: 'Switch between modes', shortcut: 'E' }],
+}
+
 const VIEWER_ACTIONS = deepFreeze(
   thru(structuredClone(DEFAULT_ACTIONS), (actions) => {
     const general = actions.find((s) => s.title === 'General shortcuts')
-    general?.actions.push({ name: 'Switch between modes', shortcut: 'E' })
+    general?.actions.push(...commonActions[general.title])
+
+    const navigation = actions.find((s) => s.title === 'Navigation')
+    navigation?.actions.push({ name: 'Navigate presentation', shortcut: CustomKeys.Presentation })
     return actions
   }),
 )
 
-const EDITOR_ACTIONS: ActionsSection[] = thru(structuredClone(VIEWER_ACTIONS), (actions) => {
+const EDITOR_ACTIONS: ActionsSection[] = thru(structuredClone(DEFAULT_ACTIONS), (actions) => {
   const general = actions.find((s) => s.title === 'General shortcuts')
   general?.actions.push(
+    ...commonActions[general.title],
     { name: 'Undo', shortcut: 'meta + Z' },
     { name: 'Redo', shortcut: 'meta + shift + Z | meta + Y' },
     { name: 'Add text', shortcut: 'T' },

--- a/client/src/components/tapestry-elements/items/text/link-tooltip/index.tsx
+++ b/client/src/components/tapestry-elements/items/text/link-tooltip/index.tsx
@@ -8,13 +8,17 @@ import { elementIdFromLink } from 'tapestry-core-client/src/components/tapestry/
 import { isHTTPURL } from 'tapestry-core/src/utils'
 import { useTapestryData } from '../../../../../pages/tapestry/tapestry-providers'
 import styles from './styles.module.css'
+import { InternalNavigationState } from 'tapestry-core-client/src/stage/controller/item-controller'
 
 function LinkElement({ link }: { link: string }) {
   const { items, groups } = useTapestryData(['items', 'groups'])
   const id = elementIdFromLink(link, items, groups)
 
   return id ? (
-    <Link to={{ search: new URL(link).search.slice(1) }} state={{ timestamp: Date.now() }}>
+    <Link
+      to={{ search: new URL(link).search.slice(1) }}
+      state={{ timestamp: Date.now() } satisfies InternalNavigationState}
+    >
       {link}
     </Link>
   ) : (

--- a/client/src/stage/controller/editor-item-controller.ts
+++ b/client/src/stage/controller/editor-item-controller.ts
@@ -3,7 +3,10 @@ import { createEventRegistry } from 'tapestry-core-client/src/lib/events/event-r
 import { EventTypes } from 'tapestry-core-client/src/lib/events/typed-events'
 import { isMeta } from 'tapestry-core-client/src/lib/keyboard-event'
 import { TapestryStage } from 'tapestry-core-client/src/stage'
-import { ItemController } from 'tapestry-core-client/src/stage/controller/item-controller'
+import {
+  InternalNavigationState,
+  ItemController,
+} from 'tapestry-core-client/src/stage/controller/item-controller'
 import {
   DomDragHandler,
   DragEndEvent,
@@ -49,8 +52,6 @@ import {
 } from '../utils'
 import { ItemResizeManager, ResizeTarget } from './item-resize-manager'
 import { ClickEvent } from 'tapestry-core-client/src/stage/gesture-detector'
-import { FocusLocationState } from 'tapestry-core-client/src/components/tapestry/hooks/use-focus-element'
-import { FocusOptions } from 'tapestry-core-client/src/view-model/store-commands/viewport'
 
 type EventTypesMap = {
   resizeHandler: EventTypes<DomDragHandler>
@@ -182,7 +183,10 @@ export class EditorItemController extends ItemController {
     attachListeners(this, 'document', document, interactionMode)
   }
 
-  protected tryNavigateToInternalState(params: URLSearchParams, animate: FocusOptions['animate']) {
+  protected tryNavigateToInternalState(
+    params: URLSearchParams,
+    state: Omit<InternalNavigationState, 'timestamp'>,
+  ) {
     const { items, groups } = this.editorStore.get(['items', 'groups'])
     const focus = params.get('focus')
     const element = focus && (items[focus] ?? groups[focus])
@@ -190,7 +194,7 @@ export class EditorItemController extends ItemController {
       void router.navigate(
         { search: params.toString() },
         {
-          state: { timestamp: Date.now(), animate } satisfies FocusLocationState,
+          state: { timestamp: Date.now(), ...state } satisfies InternalNavigationState,
           replace: new URLSearchParams(location.search).get('focus') === focus,
         },
       )

--- a/client/src/stage/controller/editor-item-controller.ts
+++ b/client/src/stage/controller/editor-item-controller.ts
@@ -49,6 +49,8 @@ import {
 } from '../utils'
 import { ItemResizeManager, ResizeTarget } from './item-resize-manager'
 import { ClickEvent } from 'tapestry-core-client/src/stage/gesture-detector'
+import { FocusLocationState } from 'tapestry-core-client/src/components/tapestry/hooks/use-focus-element'
+import { FocusOptions } from 'tapestry-core-client/src/view-model/store-commands/viewport'
 
 type EventTypesMap = {
   resizeHandler: EventTypes<DomDragHandler>
@@ -180,7 +182,7 @@ export class EditorItemController extends ItemController {
     attachListeners(this, 'document', document, interactionMode)
   }
 
-  protected tryNavigateToInternalState(params: URLSearchParams) {
+  protected tryNavigateToInternalState(params: URLSearchParams, animate: FocusOptions['animate']) {
     const { items, groups } = this.editorStore.get(['items', 'groups'])
     const focus = params.get('focus')
     const element = focus && (items[focus] ?? groups[focus])
@@ -188,7 +190,7 @@ export class EditorItemController extends ItemController {
       void router.navigate(
         { search: params.toString() },
         {
-          state: { timestamp: Date.now() },
+          state: { timestamp: Date.now(), animate } satisfies FocusLocationState,
           replace: new URLSearchParams(location.search).get('focus') === focus,
         },
       )
@@ -218,7 +220,7 @@ export class EditorItemController extends ItemController {
   protected onResizeDrag(event: DragEvent<ResizeTarget>) {
     const { dragTarget, currentPoint, originalEvent } = event.detail
     this.resizeManager.resize(dragTarget, currentPoint, {
-      snapToGrid: !originalEvent?.ctrlKey,
+      snapToGrid: !(originalEvent && isMeta(originalEvent)),
       forceLockAspectRatio: !!originalEvent?.shiftKey,
     })
   }
@@ -339,9 +341,10 @@ export class EditorItemController extends ItemController {
 
   private onDragItems(event: DragEvent<HoveredDragTarget>) {
     const { worldTransform } = this.stage.pixi.tapestry.app.stage
-    const guidelineSpacing = event.detail.originalEvent?.ctrlKey
-      ? null
-      : this.editorStore.get('viewportGuidelines.spacing')
+    const guidelineSpacing =
+      event.detail.originalEvent && isMeta(event.detail.originalEvent)
+        ? null
+        : this.editorStore.get('viewportGuidelines.spacing')
     const previousStagePoint = worldTransform.applyInverse(event.detail.previousPoint)
     const currentStagePoint = worldTransform.applyInverse(event.detail.currentPoint)
     const translation = vector(previousStagePoint, currentStagePoint)

--- a/core-client/src/components/lib/hooks/use-multiselect-menu.tsx
+++ b/core-client/src/components/lib/hooks/use-multiselect-menu.tsx
@@ -1,5 +1,9 @@
 import { deselectAll } from '../../../view-model/store-commands/tapestry'
-import { focusItems, focusPresentationStep } from '../../../view-model/store-commands/viewport'
+import {
+  defaultBounceAnimation,
+  focusItems,
+  focusPresentationStep,
+} from '../../../view-model/store-commands/viewport'
 import { getAdjacentPresentationSteps, getSelectionItems } from '../../../view-model/utils'
 import { useTapestryConfig } from '../../tapestry'
 import { FocusButton } from '../../tapestry/focus-button'
@@ -32,20 +36,13 @@ export function useMultiselectMenu<M extends MultiselectMenuItem[]>(
 
   const continuePresentation = (step: 'next' | 'prev') => {
     if (adjacentPresentationSteps && adjacentPresentationSteps[step]) {
-      dispatch(
-        focusPresentationStep(adjacentPresentationSteps[step].dto, {
-          zoomEffect: 'bounce',
-          duration: 1,
-        }),
-      )
+      dispatch(focusPresentationStep(adjacentPresentationSteps[step].dto, defaultBounceAnimation))
     }
   }
 
   useKeyboardShortcuts(
     {
       Escape: () => dispatch(deselectAll()),
-      ArrowRight: () => continuePresentation('next'),
-      ArrowLeft: () => continuePresentation('prev'),
     },
     [dispatch],
   )
@@ -88,7 +85,7 @@ export function useMultiselectMenu<M extends MultiselectMenuItem[]>(
               ),
               tooltip: {
                 side: 'bottom',
-                children: <ShortcutLabel text="Previous item">&lt;</ShortcutLabel>,
+                children: 'Previous item',
               },
             },
             {
@@ -102,7 +99,7 @@ export function useMultiselectMenu<M extends MultiselectMenuItem[]>(
               ),
               tooltip: {
                 side: 'bottom',
-                children: <ShortcutLabel text="Next item">&gt;</ShortcutLabel>,
+                children: 'Next item',
               },
             },
           ]

--- a/core-client/src/components/lib/hooks/use-presentation-shortcuts.ts
+++ b/core-client/src/components/lib/hooks/use-presentation-shortcuts.ts
@@ -1,7 +1,10 @@
 import { useKeyboardShortcuts } from './use-keyboard-shortcuts'
 import { useTapestryConfig } from '../../tapestry'
 import { getAdjacentPresentationSteps } from '../../../view-model/utils'
-import { focusPresentationStep } from '../../../view-model/store-commands/viewport'
+import {
+  defaultBounceAnimation,
+  focusPresentationStep,
+} from '../../../view-model/store-commands/viewport'
 import { useSingleGroupSelection } from './use-single-group-selection'
 import { getPresentationSequence } from 'tapestry-core/src/utils'
 import { mapValues } from 'lodash'
@@ -18,12 +21,9 @@ export function usePresentationShortcuts(enable = true) {
     : undefined
 
   useKeyboardShortcuts(
-    enable
+    enable && adjacentPresentationSteps
       ? {
           'ArrowRight | PageDown | ArrowLeft | PageUp': (e) => {
-            if (!adjacentPresentationSteps) {
-              return
-            }
             const isNext = e.code === 'ArrowRight' || e.code === 'PageDown'
             const presentation =
               isNext && adjacentPresentationSteps.next
@@ -34,10 +34,10 @@ export function usePresentationShortcuts(enable = true) {
 
             if (presentation) {
               dispatch(
-                focusPresentationStep(adjacentPresentationSteps[presentation]!.dto, {
-                  zoomEffect: 'bounce',
-                  duration: 1,
-                }),
+                focusPresentationStep(
+                  adjacentPresentationSteps[presentation]!.dto,
+                  defaultBounceAnimation,
+                ),
               )
             }
           },
@@ -46,9 +46,9 @@ export function usePresentationShortcuts(enable = true) {
             const sequence = getPresentationSequence(mapValues(presentationSteps, (vm) => vm?.dto))
 
             const step =
-              e.code === 'Home' && adjacentPresentationSteps?.prev
+              e.code === 'Home' && adjacentPresentationSteps.prev
                 ? sequence[0]
-                : e.code === 'End' && adjacentPresentationSteps?.next
+                : e.code === 'End' && adjacentPresentationSteps.next
                   ? sequence[sequence.length - 1]
                   : undefined
 

--- a/core-client/src/components/tapestry/help-pane/shortcuts-pane/index.tsx
+++ b/core-client/src/components/tapestry/help-pane/shortcuts-pane/index.tsx
@@ -11,9 +11,10 @@ export enum CustomKeys {
   Arrows = 'arrows',
   Pan = 'pan',
   Meta = 'meta',
+  Presentation = 'presentation',
 }
 
-interface Action {
+export interface Action {
   name: string
   shortcut: string
 }
@@ -88,6 +89,12 @@ const customKeysMap: Record<string, ReactNode> = {
   ],
   pan: ['Space', 'Drag'],
   meta: [isMac ? '⌘' : 'Ctrl'],
+  presentation: [
+    <Icon className={styles.icon} icon="keyboard_arrow_left" />,
+    <Icon className={styles.icon} icon="keyboard_arrow_right" />,
+    'Home',
+    'End',
+  ],
 } satisfies Record<CustomKeys, ReactNode[]>
 
 function Shortcut({ keys }: ShortcutProps) {

--- a/core-client/src/components/tapestry/hooks/use-focus-element.ts
+++ b/core-client/src/components/tapestry/hooks/use-focus-element.ts
@@ -1,8 +1,9 @@
 import { useLocation, useSearchParams } from 'react-router'
 import { useEffect, useRef } from 'react'
-import { focusGroup, focusItems, FocusOptions } from '../../../view-model/store-commands/viewport'
+import { focusGroup, focusItems } from '../../../view-model/store-commands/viewport'
 import { setInteractiveElement } from '../../../view-model/store-commands/tapestry'
 import { useTapestryConfig } from '..'
+import { InternalNavigationState } from '../../../stage/controller/item-controller'
 
 export function useFocusElement() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -11,21 +12,19 @@ export function useFocusElement() {
     setSearchParams(
       { focus: id, ...params },
       {
-        state: { timestamp: Date.now() },
+        state: { timestamp: Date.now() } satisfies InternalNavigationState,
         replace: searchParams.get('focus') === id,
       },
     )
   }
 }
 
-export type FocusLocationState = { timestamp: number; animate?: FocusOptions['animate'] }
-
 export function useFocusedElement() {
   const { useStoreData, useDispatch } = useTapestryConfig()
   const [params] = useSearchParams()
   const modelId = params.get('focus')
 
-  const locationState = useLocation().state as FocusLocationState | null
+  const locationState = useLocation().state as InternalNavigationState | null
 
   const { timestamp, animate } = locationState ?? {}
 

--- a/core-client/src/components/tapestry/hooks/use-focus-element.ts
+++ b/core-client/src/components/tapestry/hooks/use-focus-element.ts
@@ -1,6 +1,6 @@
 import { useLocation, useSearchParams } from 'react-router'
 import { useEffect, useRef } from 'react'
-import { focusGroup, focusItems } from '../../../view-model/store-commands/viewport'
+import { focusGroup, focusItems, FocusOptions } from '../../../view-model/store-commands/viewport'
 import { setInteractiveElement } from '../../../view-model/store-commands/tapestry'
 import { useTapestryConfig } from '..'
 
@@ -18,14 +18,16 @@ export function useFocusElement() {
   }
 }
 
+export type FocusLocationState = { timestamp: number; animate?: FocusOptions['animate'] }
+
 export function useFocusedElement() {
   const { useStoreData, useDispatch } = useTapestryConfig()
   const [params] = useSearchParams()
   const modelId = params.get('focus')
 
-  const locationState = useLocation().state as { timestamp: number } | null
+  const locationState = useLocation().state as FocusLocationState | null
 
-  const timestamp = locationState?.timestamp
+  const { timestamp, animate } = locationState ?? {}
 
   const elements = useStoreData(['items', 'groups'])
   const elementsRef = useRef(elements)
@@ -43,13 +45,13 @@ export function useFocusedElement() {
     const { items, groups } = elementsRef.current
     if (items[modelId]) {
       dispatch(
-        focusItems([modelId], { addToolbarPadding: true }),
+        focusItems([modelId], { addToolbarPadding: true, animate }),
         setInteractiveElement({ modelId, modelType: 'item' }),
       )
     } else if (groups[modelId]) {
-      dispatch(focusGroup(modelId))
+      dispatch(focusGroup(modelId, animate))
     } else if (modelId === 'all') {
-      dispatch(focusItems(Object.keys(items)))
+      dispatch(focusItems(Object.keys(items), { animate }))
     }
-  }, [modelId, viewportReady, dispatch, timestamp])
+  }, [modelId, viewportReady, dispatch, timestamp, animate])
 }

--- a/core-client/src/components/tapestry/hooks/use-item-menu.tsx
+++ b/core-client/src/components/tapestry/hooks/use-item-menu.tsx
@@ -3,7 +3,10 @@ import { Id } from 'tapestry-core/src/data-format/schemas/common'
 import { useTapestryConfig } from '..'
 import { shortcutLabel } from '../../../lib/keyboard-event'
 import { deselectAll, selectGroups } from '../../../view-model/store-commands/tapestry'
-import { focusPresentationStep } from '../../../view-model/store-commands/viewport'
+import {
+  defaultBounceAnimation,
+  focusPresentationStep,
+} from '../../../view-model/store-commands/viewport'
 import { getAdjacentPresentationSteps } from '../../../view-model/utils'
 import { IconButton } from '../../lib/buttons/index'
 import { useKeyboardShortcuts } from '../../lib/hooks/use-keyboard-shortcuts'
@@ -35,20 +38,13 @@ export function useItemMenu<const M extends string>(
 
   const continuePresentation = (step: 'next' | 'prev') => {
     if (adjacentPresentationSteps[step]) {
-      dispatch(
-        focusPresentationStep(adjacentPresentationSteps[step].dto, {
-          zoomEffect: 'bounce',
-          duration: 1,
-        }),
-      )
+      dispatch(focusPresentationStep(adjacentPresentationSteps[step].dto, defaultBounceAnimation))
     }
   }
 
   useKeyboardShortcuts({
     ...(menu.includes('info') ? { 'meta + KeyI': showInfo } : {}),
     Escape: () => dispatch(deselectAll()),
-    ArrowRight: () => continuePresentation('next'),
-    ArrowLeft: () => continuePresentation('prev'),
   })
 
   function showInfo() {
@@ -95,9 +91,7 @@ export function useItemMenu<const M extends string>(
           ),
           tooltip: {
             side: 'bottom',
-            children: (
-              <ShortcutLabel text={label}>{presentation === 'prev' ? '<' : '>'}</ShortcutLabel>
-            ),
+            children: label,
           },
         }
       }

--- a/core-client/src/components/tapestry/search/search-pane/search-result/index.tsx
+++ b/core-client/src/components/tapestry/search/search-pane/search-result/index.tsx
@@ -8,6 +8,7 @@ import { Text } from '../../../../../../src/components/lib/text/index'
 import { toggleOutline } from '../../../../../view-model/store-commands/tapestry'
 import { isBlobURL } from '../../../../../view-model/utils'
 import styles from './styles.module.css'
+import { InternalNavigationState } from '../../../../../stage/controller/item-controller'
 
 export interface SearchResultProps {
   type: 'text' | 'media'
@@ -36,7 +37,7 @@ export function SearchResult({
   return (
     <Link
       to={{ search: `focus=${id}` }}
-      state={{ timestamp: new Date() }}
+      state={{ timestamp: Date.now() } satisfies InternalNavigationState}
       className={clsx(styles.root, { [styles.highlighted]: highlighted })}
       onFocus={() => dispatch(toggleOutline(id))}
       onMouseOver={() => dispatch(toggleOutline(id))}

--- a/core-client/src/stage/controller/item-controller.ts
+++ b/core-client/src/stage/controller/item-controller.ts
@@ -35,6 +35,7 @@ import {
 import { isSingleGroupSelected } from '../../view-model/utils'
 import { isHTTPURL } from 'tapestry-core/src/utils'
 import { Id } from 'tapestry-core/src/data-format/schemas/common'
+import { defaultBounceAnimation, FocusOptions } from '../../view-model/store-commands/viewport'
 
 type EventTypesMap = {
   gesture: EventTypes<GestureDetector>
@@ -205,14 +206,17 @@ export abstract class ItemController implements TapestryStageController {
     this.store.dispatch(setPointerMode('pan'))
   }
 
-  protected abstract tryNavigateToInternalState(params: URLSearchParams): boolean
+  protected abstract tryNavigateToInternalState(
+    params: URLSearchParams,
+    animate: FocusOptions['animate'],
+  ): boolean
 
   protected handleActionItemClick(id: Id) {
     const item = this.store.get(`items.${id}.dto`)
     if (item?.type === 'actionButton' && item.action) {
       if (item.actionType === 'internalLink') {
         const params = new URLSearchParams(item.action)
-        return this.tryNavigateToInternalState(params)
+        return this.tryNavigateToInternalState(params, defaultBounceAnimation)
       }
 
       if (isHTTPURL(item.action)) {

--- a/core-client/src/stage/controller/item-controller.ts
+++ b/core-client/src/stage/controller/item-controller.ts
@@ -48,6 +48,11 @@ const { eventListener, attachListeners, detachListeners } = createEventRegistry<
   'desktop' | 'mobile'
 >()
 
+export interface InternalNavigationState {
+  timestamp: number
+  animate?: FocusOptions['animate']
+}
+
 export abstract class ItemController implements TapestryStageController {
   private selectionHandler!: DomDragHandler
   private longPressDetector: LongPressDetector
@@ -208,7 +213,7 @@ export abstract class ItemController implements TapestryStageController {
 
   protected abstract tryNavigateToInternalState(
     params: URLSearchParams,
-    animate: FocusOptions['animate'],
+    state: Omit<InternalNavigationState, 'timestamp'>,
   ): boolean
 
   protected handleActionItemClick(id: Id) {
@@ -216,7 +221,7 @@ export abstract class ItemController implements TapestryStageController {
     if (item?.type === 'actionButton' && item.action) {
       if (item.actionType === 'internalLink') {
         const params = new URLSearchParams(item.action)
-        return this.tryNavigateToInternalState(params, defaultBounceAnimation)
+        return this.tryNavigateToInternalState(params, { animate: defaultBounceAnimation })
       }
 
       if (isHTTPURL(item.action)) {

--- a/core-client/src/view-model/store-commands/viewport.ts
+++ b/core-client/src/view-model/store-commands/viewport.ts
@@ -37,6 +37,11 @@ import { clamp, debounce } from 'lodash-es'
 import { selectItems, setInteractiveElement } from './tapestry.js'
 import { PresentationStep } from 'tapestry-core/src/data-format/schemas/presentation-step.js'
 
+export const defaultBounceAnimation: FocusOptions['animate'] = {
+  zoomEffect: 'bounce',
+  duration: 1,
+}
+
 export const CONTINUOUS_ZOOM_SPEED = 3
 const ELEMENT_TOOLBAR_PADDING = 65
 

--- a/viewer/src/components/side-pane/index.tsx
+++ b/viewer/src/components/side-pane/index.tsx
@@ -1,16 +1,29 @@
 import { HelpPane } from 'tapestry-core-client/src/components/tapestry/help-pane'
 import { DEFAULT_GUIDE } from 'tapestry-core-client/src/components/tapestry/help-pane/guide-pane'
-import { DEFAULT_ACTIONS } from 'tapestry-core-client/src/components/tapestry/help-pane/shortcuts-pane'
+import {
+  CustomKeys,
+  DEFAULT_ACTIONS,
+} from 'tapestry-core-client/src/components/tapestry/help-pane/shortcuts-pane'
 import { SearchPane } from 'tapestry-core-client/src/components/tapestry/search/search-pane'
 import { SidePane as BaseSidePane } from 'tapestry-core-client/src/components/tapestry/side-pane/index.js'
 import { useTapestryData } from '../../app'
+import { deepFreeze } from 'tapestry-core/src/utils'
+import { thru } from 'lodash'
+
+const VIEWER_ACTIONS = deepFreeze(
+  thru(structuredClone(DEFAULT_ACTIONS), (actions) => {
+    const navigation = actions.find((s) => s.title === 'Navigation')
+    navigation?.actions.push({ name: 'Navigate presentation', shortcut: CustomKeys.Presentation })
+    return actions
+  }),
+)
 
 export function SidePane() {
   const displaySidePane = useTapestryData('displaySidePane')
 
   const isHelpPanel = displaySidePane === 'guide' || displaySidePane === 'shortcuts'
   const content = isHelpPanel ? (
-    <HelpPane sidePaneType={displaySidePane} guide={DEFAULT_GUIDE} shortcuts={DEFAULT_ACTIONS} />
+    <HelpPane sidePaneType={displaySidePane} guide={DEFAULT_GUIDE} shortcuts={VIEWER_ACTIONS} />
   ) : displaySidePane === 'search' ? (
     <SearchPane />
   ) : undefined

--- a/viewer/src/components/tapestry/index.tsx
+++ b/viewer/src/components/tapestry/index.tsx
@@ -12,7 +12,10 @@ import { useNavigate } from 'react-router'
 import { createPixiApp } from 'tapestry-core-client/src/stage'
 import { TapestryLifecycleController } from 'tapestry-core-client/src/stage/controller'
 import { GlobalEventsController } from 'tapestry-core-client/src/stage/controller/global-events-controller'
-import { ItemController } from 'tapestry-core-client/src/stage/controller/item-controller'
+import {
+  InternalNavigationState,
+  ItemController,
+} from 'tapestry-core-client/src/stage/controller/item-controller'
 import { ViewportController } from 'tapestry-core-client/src/stage/controller/viewport-controller'
 import { ItemThumbnailController } from 'tapestry-core-client/src/stage/controller/item-thumbnail-controller'
 import { TapestryRenderer } from 'tapestry-core-client/src/stage/renderer'
@@ -20,7 +23,6 @@ import { idMapToArray } from 'tapestry-core/src/utils'
 import { useTapestryData, useTapestryStore } from '../../app'
 import { SidePane } from '../side-pane'
 import { TopToolbar } from '../top-toolbar'
-import { FocusOptions } from 'tapestry-core-client/src/view-model/store-commands/viewport'
 
 interface TapestryProps {
   onBack: () => unknown
@@ -63,7 +65,7 @@ export function Tapestry({ onBack }: TapestryProps) {
           new (class extends ItemController {
             protected tryNavigateToInternalState(
               params: URLSearchParams,
-              animate: FocusOptions['animate'],
+              state: Omit<InternalNavigationState, 'timestamp'>,
             ) {
               const { items, groups } = store.get(['items', 'groups'])
               const focus = params.get('focus')
@@ -72,7 +74,7 @@ export function Tapestry({ onBack }: TapestryProps) {
                 void navigate(
                   { search: params.toString() },
                   {
-                    state: { timestamp: Date.now(), animate },
+                    state: { timestamp: Date.now(), ...state } satisfies InternalNavigationState,
                     replace: new URLSearchParams(location.search).get('focus') === focus,
                   },
                 )

--- a/viewer/src/components/tapestry/index.tsx
+++ b/viewer/src/components/tapestry/index.tsx
@@ -20,6 +20,7 @@ import { idMapToArray } from 'tapestry-core/src/utils'
 import { useTapestryData, useTapestryStore } from '../../app'
 import { SidePane } from '../side-pane'
 import { TopToolbar } from '../top-toolbar'
+import { FocusOptions } from 'tapestry-core-client/src/view-model/store-commands/viewport'
 
 interface TapestryProps {
   onBack: () => unknown
@@ -60,15 +61,18 @@ export function Tapestry({ onBack }: TapestryProps) {
         ],
         global: [
           new (class extends ItemController {
-            protected tryNavigateToInternalState(params: URLSearchParams) {
+            protected tryNavigateToInternalState(
+              params: URLSearchParams,
+              animate: FocusOptions['animate'],
+            ) {
               const { items, groups } = store.get(['items', 'groups'])
               const focus = params.get('focus')
               const element = focus && (items[focus] ?? groups[focus])
-              if (element) {
+              if (element || focus === 'all') {
                 void navigate(
                   { search: params.toString() },
                   {
-                    state: { timestamp: Date.now() },
+                    state: { timestamp: Date.now(), animate },
                     replace: new URLSearchParams(location.search).get('focus') === focus,
                   },
                 )


### PR DESCRIPTION
1. Animation settings can now be passed to navigation state.
2. Removed presentation shortcuts from item toolbars since we have a separate hook for them.
3. Fixed the viewer keyboard arrow pan, by tweaking the presentation hook.
4. Fixed a bug where ctrl key was being checked instead of meta key when dragging and resizing.
5. Added presentation navigation controls to shortcuts help pane.