### PR TITLE
Add puppeteer autoconsent

### DIFF
--- a/client/src/components/tapestry-elements/items/wayback-page/index.tsx
+++ b/client/src/components/tapestry-elements/items/wayback-page/index.tsx
@@ -109,7 +109,7 @@ export const WaybackPageItem = memo(({ id }: TapestryItemProps) => {
 
   useEffect(() => setLoading(true), [wbmSource])
 
-  const { conversionStarted, convertToPDFToolbarElement } = useConvertToPDF(id)
+  const { conversionStarted, convertToPDFMenuItem } = useConvertToPDF(id)
 
   const {
     snapshots,
@@ -185,12 +185,11 @@ export const WaybackPageItem = memo(({ id }: TapestryItemProps) => {
             'separator',
             refreshButton,
             'separator',
-            convertToPDFToolbarElement,
-            'separator',
             ...controls,
           ]
         : [refreshButton, 'separator', ...controls]
     },
+    moreMenuItems: [convertToPDFMenuItem],
   })
 
   const missingSnapshotsMessage =

--- a/client/src/components/tapestry-elements/items/webpage/index.tsx
+++ b/client/src/components/tapestry-elements/items/webpage/index.tsx
@@ -101,7 +101,7 @@ export const WebpageItem = memo(({ id }: TapestryItemProps) => {
   const webSourceParams = parseWebSource(dto)
   const { webpageType } = webSourceParams
 
-  const { conversionStarted, convertToPDFToolbarElement } = useConvertToPDF(id)
+  const { conversionStarted, convertToPDFMenuItem } = useConvertToPDF(id)
 
   const dispatch = useDispatch()
   const patch = ({ webpageType, data }: PatchSourceArgument) =>
@@ -189,16 +189,12 @@ export const WebpageItem = memo(({ id }: TapestryItemProps) => {
             },
             'separator',
             refreshButton,
-            'separator',
-            ...(!(webpageType && PLAYABLE_WEBPAGE_TYPES.includes(webpageType))
-              ? ([convertToPDFToolbarElement, 'separator'] as const)
-              : []),
             ...controls,
           ]
         : [refreshButton, 'separator', ...controls]
     },
-    moreMenuItems:
-      webpageType === 'youtube' || webpageType === 'vimeo'
+    moreMenuItems: [
+      ...(webpageType === 'youtube' || webpageType === 'vimeo'
         ? [
             <TimeInput
               onChange={(value) => patch({ webpageType: webpageType, data: { startTime: value } })}
@@ -223,7 +219,11 @@ export const WebpageItem = memo(({ id }: TapestryItemProps) => {
                 value={startTime ?? null}
               />,
             ]
-          : undefined,
+          : []),
+      ...(!(webpageType && PLAYABLE_WEBPAGE_TYPES.includes(webpageType))
+        ? [convertToPDFMenuItem]
+        : []),
+    ],
   })
 
   return (

--- a/client/src/hooks/use-convert-to-pdf.tsx
+++ b/client/src/hooks/use-convert-to-pdf.tsx
@@ -1,8 +1,7 @@
 import { useAsyncAction } from 'tapestry-core-client/src/components/lib/hooks/use-async-action'
 import { resource } from '../services/rest-resources'
 import { LoadingSpinner } from 'tapestry-core-client/src/components/lib/loading-spinner'
-import { ToolbarElement } from 'tapestry-core-client/src/components/lib/toolbar'
-import { IconButton } from 'tapestry-core-client/src/components/lib/buttons'
+import { MenuItemButton } from 'tapestry-core-client/src/components/lib/buttons'
 
 export function useConvertToPDF(id: string) {
   const { trigger, loading, data } = useAsyncAction(({ signal }) =>
@@ -14,13 +13,11 @@ export function useConvertToPDF(id: string) {
   return {
     convertToPDF: trigger,
     conversionStarted,
-    convertToPDFToolbarElement: {
-      element: conversionStarted ? (
-        <LoadingSpinner style={{ alignSelf: 'center' }} size="16px" />
-      ) : (
-        <IconButton icon="picture_as_pdf" aria-label="Convert to PDF" onClick={trigger} />
-      ),
-      tooltip: { side: 'bottom', children: 'Convert to PDF' },
-    } satisfies ToolbarElement,
+    convertToPDFMenuItem: (
+      <MenuItemButton onClick={trigger} disabled={conversionStarted}>
+        Convert to PDF
+        {conversionStarted && <LoadingSpinner style={{ alignSelf: 'center' }} size="16px" />}
+      </MenuItemButton>
+    ),
   }
 }

--- a/core/eslint.config-base.mts
+++ b/core/eslint.config-base.mts
@@ -27,7 +27,10 @@ export default tseslint.config({
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
     '@typescript-eslint/consistent-type-definitions': 'off',
-    '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    '@typescript-eslint/switch-exhaustiveness-check': [
+      'error',
+      { considerDefaultExhaustiveForUnions: true },
+    ],
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/prefer-nullish-coalescing': [
       'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,6 +1836,15 @@
         "url": "https://github.com/sponsors/JounQin"
       }
     },
+    "node_modules/@duckduckgo/autoconsent": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.9.0.tgz",
+      "integrity": "sha512-f0xwshjJpkNKuMTa8lPH4KRrIAkMRUaSbw4PJiDSy3piYi/wvj9U8mvb6inYr/FO1MZ8KpykIDS2MBhY3958Jw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "tldts-experimental": "^7.4.3"
+      }
+    },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
@@ -14374,6 +14383,21 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-experimental": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.8.tgz",
+      "integrity": "sha512-BhnfwjtvAhq2ea0vglBojLEvn2QtZFZenstPQt75O8RtSqf8Xgh2vh7ksD4afpKwqjUNKg9ze2f18C8KbmSy7A==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15772,6 +15796,7 @@
         "@bull-board/api": "^6.11.2",
         "@bull-board/express": "^6.11.2",
         "@dotenvx/dotenvx": "^1.35.0",
+        "@duckduckgo/autoconsent": "^16.9.0",
         "@litehex/node-vault": "^1.0.4",
         "@prisma/client": "^6.3.1",
         "@sentry/node": "^10.33.0",

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "@bull-board/api": "^6.11.2",
     "@bull-board/express": "^6.11.2",
     "@dotenvx/dotenvx": "^1.35.0",
+    "@duckduckgo/autoconsent": "^16.9.0",
     "@litehex/node-vault": "^1.0.4",
     "@prisma/client": "^6.3.1",
     "@sentry/node": "^10.33.0",

--- a/server/src/tasks/autoconsent.ts
+++ b/server/src/tasks/autoconsent.ts
@@ -1,0 +1,131 @@
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { Page } from 'puppeteer'
+import { pageEval } from './utils'
+import {
+  BackgroundMessage,
+  Config,
+  ContentScriptMessage,
+  RuleBundle,
+} from '@duckduckgo/autoconsent'
+
+export class AutoconsentError extends Error {}
+
+export const autoconsentScript = readFileSync(
+  resolve(
+    dirname(fileURLToPath(import.meta.resolve('@duckduckgo/autoconsent'))),
+    'autoconsent.playwright.js',
+  ),
+  'utf8',
+)
+
+// Load the rule bundles shipped with the package
+const rules = JSON.parse(
+  readFileSync(
+    fileURLToPath(import.meta.resolve('@duckduckgo/autoconsent/rules/rules.json')),
+    'utf8',
+  ),
+) as RuleBundle
+
+// See https://github.com/duckduckgo/autoconsent/blob/main/docs/api.md
+const autoconsentConfig: Partial<Config> = {
+  enabled: true,
+  autoAction: 'optOut',
+  disabledCmps: [],
+  enablePrehide: true,
+  enableCosmeticRules: true,
+  enableGeneratedRules: true,
+  detectRetries: 4,
+  isMainWorld: false,
+  enableHeuristicDetection: true,
+  heuristicMode: 'tier2',
+  logs: {
+    lifecycle: false,
+    rulesteps: false,
+    detectionsteps: false,
+    evals: false,
+    errors: true,
+    messages: false,
+    waits: false,
+  },
+}
+
+const sendMessage = async (page: Page, message: BackgroundMessage) =>
+  pageEval(
+    page,
+    (w, msg) => {
+      const window = w as { autoconsentReceiveMessage?: (msg: BackgroundMessage) => Promise<void> }
+      if (window.autoconsentReceiveMessage) {
+        return window.autoconsentReceiveMessage(msg)
+      }
+    },
+    message,
+  )
+
+export async function attatchAutoconsent(page: Page, timeout: number): Promise<string> {
+  return new Promise((res, rej) => {
+    let completed = false
+
+    function complete(msg: string, resolve: true): void
+    function complete(msg: unknown, resolve: false): void
+    function complete(msg: unknown, resolve: boolean) {
+      if (!completed) {
+        completed = true
+        if (resolve) {
+          res(msg as string)
+        } else {
+          rej(
+            msg instanceof Error
+              ? msg
+              : new AutoconsentError(typeof msg === 'string' ? msg : 'Unknown error'),
+          )
+        }
+        clearTimeout(t)
+      }
+    }
+
+    const t = setTimeout(() => {
+      complete(`Timed out after ${timeout}ms`, false)
+    }, timeout)
+
+    page
+      .exposeFunction('autoconsentSendMessage', async (message?: ContentScriptMessage) => {
+        if (!message || typeof message !== 'object') return
+
+        switch (message.type) {
+          case 'init':
+            return sendMessage(page, {
+              type: 'initResp',
+              config: autoconsentConfig as Config,
+              rules,
+            })
+
+          case 'eval': {
+            const result = await page.evaluate(message.code)
+            return sendMessage(page, {
+              type: 'evalResp',
+              id: message.id,
+              result,
+            })
+          }
+
+          case 'autoconsentDone':
+            complete(`Duration: ${message.duration}ms`, true)
+            break
+          case 'autoconsentError':
+            complete(message.details, false)
+            break
+          case 'report':
+            if (message.state.lifecycle === 'nothingDetected') {
+              complete('Nothing detected', false)
+            }
+            break
+          default:
+            break
+        }
+      })
+      .then(() => page.evaluate(autoconsentScript))
+      .catch((e) => complete(e, false))
+  })
+}

--- a/server/src/tasks/autoconsent.ts
+++ b/server/src/tasks/autoconsent.ts
@@ -51,15 +51,14 @@ const autoconsentConfig: Partial<Config> = {
   },
 }
 
+interface AutoconsentWindow {
+  autoconsentReceiveMessage?: (msg: BackgroundMessage) => Promise<void>
+}
+
 const sendMessage = async (page: Page, message: BackgroundMessage) =>
   pageEval(
     page,
-    (w, msg) => {
-      const window = w as { autoconsentReceiveMessage?: (msg: BackgroundMessage) => Promise<void> }
-      if (window.autoconsentReceiveMessage) {
-        return window.autoconsentReceiveMessage(msg)
-      }
-    },
+    (window, msg) => (window as AutoconsentWindow).autoconsentReceiveMessage?.(msg),
     message,
   )
 
@@ -70,19 +69,20 @@ export async function attatchAutoconsent(page: Page, timeout: number): Promise<s
     function complete(msg: string, resolve: true): void
     function complete(msg: unknown, resolve: false): void
     function complete(msg: unknown, resolve: boolean) {
-      if (!completed) {
-        completed = true
-        if (resolve) {
-          res(msg as string)
-        } else {
-          rej(
-            msg instanceof Error
-              ? msg
-              : new AutoconsentError(typeof msg === 'string' ? msg : 'Unknown error'),
-          )
-        }
-        clearTimeout(t)
+      if (completed) {
+        return
       }
+      completed = true
+      if (resolve) {
+        res(msg as string)
+      } else {
+        rej(
+          msg instanceof Error
+            ? msg
+            : new AutoconsentError(typeof msg === 'string' ? msg : 'Unknown error'),
+        )
+      }
+      clearTimeout(t)
     }
 
     const t = setTimeout(() => {
@@ -118,7 +118,7 @@ export async function attatchAutoconsent(page: Page, timeout: number): Promise<s
             break
           case 'report':
             if (message.state.lifecycle === 'nothingDetected') {
-              complete('Nothing detected', false)
+              complete('Nothing detected', true)
             }
             break
           default:

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -7,6 +7,11 @@ import { DBSubscriber } from '../socket'
 import { pick } from 'lodash-es'
 import { Item } from '@prisma/client'
 
+const MIN_PDF_PAGE = {
+  width: 600,
+  height: 2000,
+}
+
 const CONVERT_ITEM_PROPS = [
   'positionX',
   'positionY',
@@ -22,7 +27,7 @@ async function convertWebpageToPdf(url: string, options?: PDFOptions) {
   try {
     console.log(`Converting ${url} to pdf...`)
     generator = inNewBrowserPage(async function* (page, context): AsyncGenerator<Uint8Array> {
-      await initWebpage(page, context, { url })
+      await initWebpage(page, context, { url, autoconsent: true })
       console.log('>  Converting to pdf...')
       yield page.pdf(options)
     })
@@ -37,6 +42,7 @@ async function convertWebpageToPdf(url: string, options?: PDFOptions) {
 }
 
 export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
+  let s3Key: string | null = null
   try {
     const item = await prisma.item.findUniqueOrThrow({
       where: { id: itemId },
@@ -47,23 +53,23 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
     }
 
     const value = await convertWebpageToPdf(item.source, {
-      width: item.width,
-      height: item.height,
+      width: Math.max(item.width, MIN_PDF_PAGE.width),
+      height: Math.max(item.height, MIN_PDF_PAGE.height),
     })
 
-    await prisma.$transaction(async (tx) => {
-      await tx.item.delete({ where: { id: item.id } })
+    s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)
+    await s3Service.putObject(s3Key, value, 'application/pdf')
 
-      const s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)
+    await prisma.$transaction(async (tx) => {
+      const deletedItem = await tx.item.delete({ where: { id: item.id } })
       await tx.item.create({
         data: {
-          ...pick(item, CONVERT_ITEM_PROPS),
+          ...pick(deletedItem, CONVERT_ITEM_PROPS),
           type: 'pdf',
           source: s3Key,
           scheduledThumbnailProcessing: 'derive',
         },
       })
-      await s3Service.putObject(s3Key, value, 'application/pdf')
     })
 
     await scheduleTapestryThumbnailGeneration(item.tapestryId)
@@ -74,6 +80,9 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
       deletedIds: { items: [item.id] },
     })
   } catch (error) {
+    if (s3Key) {
+      await s3Service.tryDeleteObject(s3Key)
+    }
     console.error(`Error while converting item ${itemId} to pdf`, error)
   }
 }

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -42,7 +42,6 @@ async function convertWebpageToPdf(url: string, options?: PDFOptions) {
 }
 
 export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
-  let s3Key: string | null = null
   try {
     const item = await prisma.item.findUniqueOrThrow({
       where: { id: itemId },
@@ -57,7 +56,7 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
       height: Math.max(item.height, MIN_PDF_PAGE.height),
     })
 
-    s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)
+    const s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)
     await s3Service.putObject(s3Key, value, 'application/pdf')
 
     await prisma.$transaction(async (tx) => {
@@ -80,9 +79,6 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
       deletedIds: { items: [item.id] },
     })
   } catch (error) {
-    if (s3Key) {
-      await s3Service.tryDeleteObject(s3Key)
-    }
     console.error(`Error while converting item ${itemId} to pdf`, error)
   }
 }

--- a/server/src/tasks/thumbnail-generators/tapestry.ts
+++ b/server/src/tasks/thumbnail-generators/tapestry.ts
@@ -8,22 +8,9 @@ import { generateThumbnail } from './image.js'
 import { Page, ScreenshotOptions } from 'puppeteer'
 import { Item } from '@prisma/client'
 import { innerFit } from 'tapestry-core/src/lib/geometry.js'
-import { initWebpage, inNewBrowserPage, WebpageConfig } from '../utils.js'
+import { initWebpage, inNewBrowserPage, pageEval, WebpageConfig } from '../utils.js'
 
 const MAX_ITEM_SIZE = 2000
-
-// Helper function that wraps Puppeteer's page.evaluate to avoid TS errors for missing browser (DOM) types
-async function pageEval<T extends unknown[], R>(
-  page: Page,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  callback: (global: any, ...args: T) => R,
-  ...args: T
-) {
-  // @ts-expect-error This will be executed in a browser context
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return
-  const globalHandle = await page.evaluateHandle(() => window)
-  return page.evaluate(callback, globalHandle, ...args)
-}
 
 async function takeItemScreenshot(page: Page, item: Item) {
   const size = innerFit(item, { width: MAX_ITEM_SIZE, height: MAX_ITEM_SIZE })

--- a/server/src/tasks/utils.ts
+++ b/server/src/tasks/utils.ts
@@ -12,7 +12,22 @@ import { config } from '../config'
 import puppeteer, { BrowserContext, Page } from 'puppeteer'
 import { Size } from 'tapestry-core/src/lib/geometry'
 import { WithOptional } from 'tapestry-core/src/type-utils'
+import { attatchAutoconsent, AutoconsentError } from './autoconsent'
 
+const AUTOCONSENT_TIMEOUT = 20_000
+
+// Helper function that wraps Puppeteer's page.evaluate to avoid TS errors for missing browser (DOM) types
+export async function pageEval<T extends unknown[], R>(
+  page: Page,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callback: (global: any, ...args: T) => R,
+  ...args: T
+) {
+  // @ts-expect-error This will be executed in a browser context
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return
+  const globalHandle = await page.evaluateHandle(() => window)
+  return page.evaluate(callback, globalHandle, ...args)
+}
 export interface DownloadOpts {
   timeoutMs?: number
   maxBytes?: number
@@ -166,23 +181,40 @@ export interface WebpageConfig {
   url: string
   windowSize: Size
   timeout?: number
+  autoconsent?: boolean
   setupContext?: (context: BrowserContext) => Promise<void>
 }
 
 export async function initWebpage(
   page: Page,
   context: BrowserContext,
-  { url, windowSize, setupContext, timeout }: WithOptional<WebpageConfig, 'windowSize'>,
+  {
+    url,
+    windowSize,
+    setupContext,
+    timeout,
+    autoconsent,
+  }: WithOptional<WebpageConfig, 'windowSize'>,
 ) {
   console.log('>  Setting up context...')
   await setupContext?.(context)
+
   if (windowSize) {
     console.log('>  Configuring viewport...')
     await page.setViewport({ ...windowSize, deviceScaleFactor: 2 })
   }
   console.log(`>  Navigating to ${url}...`)
   await page.goto(url, { timeout: 120_000 })
+
   try {
+    let autoconsentPromise: Promise<string | void> | undefined
+    if (autoconsent) {
+      autoconsentPromise = attatchAutoconsent(page, AUTOCONSENT_TIMEOUT)
+        .then((res) => console.log(`Autoconsent completed: ${res}`))
+        .catch((e) =>
+          console.log(`Autoconsent failed: ${e instanceof AutoconsentError ? e.message : e}`),
+        )
+    }
     console.log(`>  Waiting for network idle...`)
     await page.waitForNetworkIdle({
       idleTime: 3000,
@@ -193,6 +225,11 @@ export async function initWebpage(
     // @ts-expect-error The following expression will be evaluated in the browser context
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     await page.evaluate(() => document.fonts.ready)
+
+    if (autoconsent) {
+      console.log(`>  Waiting for autoconsent`)
+      await autoconsentPromise
+    }
   } catch (error) {
     console.warn('Error while waiting for the page to load. Proceeding anyway', error)
   }


### PR DESCRIPTION
[https://github.com/duckduckgo/autoconsent/blob/main/docs/puppeteer.md](https://github.com/duckduckgo/autoconsent/blob/main/docs/puppeteer.md)
Removes cookie banners in around 40% of the cases.
Currently enabled only for PDF conversion.
Moved PDF button to more menu since it is not so important.
Set a minimum size for PDFs since its layout is bad when its width is too small, and also too many pages appear if the height is too small.