### PR TITLE
Fix pdf unmount crash

### DIFF
--- a/core-client/src/components/tapestry/items/pdf/viewer.tsx
+++ b/core-client/src/components/tapestry/items/pdf/viewer.tsx
@@ -123,7 +123,9 @@ export function PdfItemViewer({ id, onDocumentLoaded, onPageChanged, apiRef }: P
 
   useImperativeHandle(apiRef, () => ({ navigateToPage }))
 
-  useEffect(() => navigateToPage(initialPage, 'instant'), [initialPage, navigateToPage])
+  useEffect(() => {
+    navigateToPage(initialPage, 'instant')
+  }, [initialPage, navigateToPage])
 
   return (
     <>


### PR DESCRIPTION
On some devices the application crashes when a pdf is deleted, or dragged. This is caused by a useEffect in the pdf viewer, whose callback in some cases returns null instead of undefined (when documentRef.current is null). useEffects should always return undefined(void) or a cleanup function, otherwise the application crashes.