### PR TITLE
Change rel arrowheads

### DIFF
--- a/client/src/stage/renderer/presentation-order-renderer.ts
+++ b/client/src/stage/renderer/presentation-order-renderer.ts
@@ -280,7 +280,6 @@ export class PresentationOrderRenderer implements Renderer<EditableTapestryViewM
         from: { point: from, direction: tangents[index - 1] },
         to: { point: to, direction: tangents[index] && mul(-1, tangents[index]) },
         controlPointOffsetRange: { min: 30, max: 150 },
-        lineWidth: 3,
       })
 
       const id = dto.type === 'item' ? dto.itemId : dto.groupId

--- a/client/src/stage/renderer/rel-renderer.tsx
+++ b/client/src/stage/renderer/rel-renderer.tsx
@@ -39,9 +39,14 @@ export class EditorRelRenderer extends RelRenderer<EditableRelViewModel> {
     return state
   }
 
-  protected computeRelCurvePoints(viewModel: EditableRelViewModel, items: IdMap<ItemViewModel>) {
+  protected computeRelCurvePoints(
+    viewModel: EditableRelViewModel,
+    relScale: number,
+    items: IdMap<ItemViewModel>,
+  ) {
     return computeRelCurvePoints<EditableRelViewModel>(
       viewModel,
+      relScale,
       items,
       (relViewModel, endpoint) => {
         if (
@@ -80,6 +85,7 @@ export class EditorRelRenderer extends RelRenderer<EditableRelViewModel> {
     fromItem,
     toItem,
     theme,
+    relScale,
   }: RelRenderState<EditableRelViewModel>):
     | (CommentsIndicatorContainerState & { position: Point })
     | undefined {
@@ -87,7 +93,7 @@ export class EditorRelRenderer extends RelRenderer<EditableRelViewModel> {
       return
     }
 
-    const curve = this.computeRelCurvePoints(viewModel, {
+    const curve = this.computeRelCurvePoints(viewModel, relScale, {
       [fromItem.dto.id]: fromItem,
       [toItem.dto.id]: toItem,
     })

--- a/core-client/src/stage/renderer/rel-renderer.ts
+++ b/core-client/src/stage/renderer/rel-renderer.ts
@@ -1,6 +1,12 @@
 import { Graphics, Point, StrokeStyle } from 'pixi.js'
 import { TapestryElementRenderer } from './tapestry-element-renderer'
-import { mul, Point as TapestryPoint, translate, Vector } from 'tapestry-core/src/lib/geometry'
+import {
+  angleX,
+  mul,
+  Point as TapestryPoint,
+  translate,
+  Vector,
+} from 'tapestry-core/src/lib/geometry'
 import { Store } from '../../lib/store/index'
 import { IdMap } from 'tapestry-core/src/utils'
 import { isHoveredElement } from '../utils'
@@ -19,8 +25,7 @@ const DEFAULT_REL_Z_INDEX = 0
 const LINE_SMOOTHNESS = 0.7
 
 const SCALE_LOG_BASE = 1.3
-const MAX_LINE_STROKE_VISIBLE_SHRINK = 0.35
-const MAX_ARROW_VISIBLE_SHRINK = 0.15
+const MIN_REL_VISIBLE_SCALING = 0.4
 
 export function drawCurve(gfx: Graphics, curve: Curve, part: 'full' | 'head' | 'tail' = 'full') {
   const start = part === 'tail' ? curve.points.middle : curve.points.start
@@ -52,8 +57,7 @@ export interface RelRenderState<R extends RelViewModel> {
   toItem?: ItemViewModel
   isHighlighted: boolean
   theme: ThemeName
-  lineStrokeScale: number
-  arrowScale: number
+  relScale: number
 }
 
 export class RelRenderer<R extends RelViewModel> extends TapestryElementRenderer<
@@ -81,8 +85,8 @@ export class RelRenderer<R extends RelViewModel> extends TapestryElementRenderer
     this.pixiContainer.addChild(this.toArrowhead)
   }
 
-  protected computeRelCurvePoints(viewModel: R, items: IdMap<ItemViewModel>) {
-    return computeRelCurvePoints(viewModel, items)
+  protected computeRelCurvePoints(viewModel: R, relScale: number, items: IdMap<ItemViewModel>) {
+    return computeRelCurvePoints(viewModel, relScale, items)
   }
 
   protected obtainRenderState(viewModel: R, store: Store<TapestryViewModel>): RelRenderState<R> {
@@ -104,8 +108,7 @@ export class RelRenderer<R extends RelViewModel> extends TapestryElementRenderer
         isInteractive ||
         (isHoveredElement(pointerInteractionTarget) && pointerInteractionTarget.modelId === id),
       theme: store.get('theme'),
-      lineStrokeScale: Math.max(1, MAX_LINE_STROKE_VISIBLE_SHRINK / discreteScale),
-      arrowScale: Math.max(1, MAX_ARROW_VISIBLE_SHRINK / discreteScale),
+      relScale: Math.max(1, MIN_REL_VISIBLE_SCALING / discreteScale),
     }
   }
 
@@ -126,18 +129,18 @@ export class RelRenderer<R extends RelViewModel> extends TapestryElementRenderer
 
     if (!state.fromItem || !state.toItem) return
 
-    const curve = this.computeRelCurvePoints(state.viewModel, {
+    const curve = this.computeRelCurvePoints(state.viewModel, state.relScale, {
       [state.fromItem.dto.id]: state.fromItem,
       [state.toItem.dto.id]: state.toItem,
     })
 
-    const arrowHeadSize = REL_ARROWHEAD_SIZES[weight] * state.arrowScale
-    const lineStrokeWidth = REL_LINE_WIDTHS[weight] * state.lineStrokeScale
+    const arrowHeadSize = REL_ARROWHEAD_SIZES[weight] * state.relScale
+    const lineStrokeWidth = REL_LINE_WIDTHS[weight] * state.relScale
 
     // Instead of a single cubic Bezier curve, draw two quadratic Bezier curves joined in the middle.
     // This way we will have two separate segments of the curve and we will be able to handle
     // user interactions with them more easily.
-    drawCurve(this.line, curve).stroke({ width: lineStrokeWidth, color, cap: 'square' })
+    drawCurve(this.line, curve).stroke({ width: lineStrokeWidth, color, cap: 'butt' })
 
     const highlightStrokeStyle: StrokeStyle = {
       width: 4 * lineStrokeWidth,
@@ -151,25 +154,11 @@ export class RelRenderer<R extends RelViewModel> extends TapestryElementRenderer
     this.lineHighlightFrom.alpha = this.lineHighlightTo.alpha = state.isHighlighted ? 0.1 : 0
 
     if (from.arrowhead === 'arrow') {
-      this.drawArrowhead(
-        this.fromArrowhead,
-        curve.from,
-        curve.fromDirection,
-        arrowHeadSize,
-        color,
-        lineStrokeWidth,
-      )
+      this.drawArrowhead(this.fromArrowhead, curve.from, curve.fromDirection, arrowHeadSize, color)
     }
 
     if (to.arrowhead === 'arrow') {
-      this.drawArrowhead(
-        this.toArrowhead,
-        curve.to,
-        curve.toDirection,
-        arrowHeadSize,
-        color,
-        lineStrokeWidth,
-      )
+      this.drawArrowhead(this.toArrowhead, curve.to, curve.toDirection, arrowHeadSize, color)
     }
   }
 
@@ -179,36 +168,14 @@ export class RelRenderer<R extends RelViewModel> extends TapestryElementRenderer
     dir: Vector,
     size: number,
     color: string,
-    strokeWidth: number,
   ) {
-    const middle = translate(point, mul(strokeWidth / 2, dir))
+    const corner = size / 8
+    const triangleRadius = size / 2
+    const middle = translate(point, mul(triangleRadius - corner * (Math.sqrt(2) - 1), dir))
     const midpoint = new Point(middle.x, middle.y)
-    const direction = new Point(dir.dx, dir.dy)
-    const degrees = Math.PI / 5
-    const cos = Math.cos(degrees)
-    const sin = Math.sin(degrees)
-    const arrowCorner1 = midpoint.add(
-      new Point(
-        (direction.dot({ x: cos, y: sin }) * size) / cos,
-        (direction.dot({ x: -sin, y: cos }) * size) / cos,
-      ),
-    )
-    const arrowCorner2 = midpoint.add(
-      new Point(
-        (direction.dot({ x: cos, y: -sin }) * size) / cos,
-        (direction.dot({ x: sin, y: cos }) * size) / cos,
-      ),
-    )
 
     graphics
-      .moveTo(arrowCorner1.x, arrowCorner1.y)
-      .lineTo(midpoint.x, midpoint.y)
-      .lineTo(arrowCorner2.x, arrowCorner2.y)
-      .stroke({
-        color,
-        cap: 'butt',
-        join: 'miter',
-        width: strokeWidth,
-      })
+      .roundPoly(midpoint.x, midpoint.y, triangleRadius, 3, corner, angleX(dir) + Math.PI / 6)
+      .fill({ color })
   }
 }

--- a/core-client/src/view-model/rel-geometry.ts
+++ b/core-client/src/view-model/rel-geometry.ts
@@ -49,16 +49,21 @@ interface CurveParams {
   from: CurveEndpointParams
   to: CurveEndpointParams
   controlPointOffsetRange: Range
-  lineWidth: number
+  arrowheadSize?: number
 }
 
-export function computeCurvePoints({ from, to, controlPointOffsetRange, lineWidth }: CurveParams) {
+export function computeCurvePoints({
+  from,
+  to,
+  controlPointOffsetRange,
+  arrowheadSize = 0,
+}: CurveParams) {
   const curvePoints: Partial<CurvePoints> = {}
 
   const endpointDistance = distance(from.point, to.point)
 
   function computeSemiCurvePoints({ point, hasArrow }: CurveEndpointParams, direction: Vector) {
-    const curveEndpoint = hasArrow ? translate(point, mul(lineWidth / 2, direction)) : point
+    const curveEndpoint = hasArrow ? translate(point, mul(arrowheadSize / 2, direction)) : point
     const dist = norm(mul(endpointDistance, direction)) / 3
     const controlPoint = translate(
       curveEndpoint,
@@ -108,6 +113,7 @@ export function computeCurvePoints({ from, to, controlPointOffsetRange, lineWidt
 
 export function computeRelCurvePoints<R extends RelViewModel>(
   relViewModel: R,
+  relScale: number,
   items: IdMap<ItemViewModel>,
   getArrowEndpoint = (relViewModel: R, endpoint: 'from' | 'to') =>
     defaultGetArrowEndpoint(relViewModel, endpoint, items),
@@ -123,15 +129,15 @@ export function computeRelCurvePoints<R extends RelViewModel>(
     from: {
       point: getArrowEndpoint(relViewModel, 'from'),
       direction: computeAnchoredCurveDirection(relViewModel, 'from'),
-      hasArrow: from.arrowhead === 'none',
+      hasArrow: from.arrowhead === 'arrow',
     },
     to: {
       point: getArrowEndpoint(relViewModel, 'to'),
       direction: computeAnchoredCurveDirection(relViewModel, 'to'),
-      hasArrow: to.arrowhead === 'none',
+      hasArrow: to.arrowhead === 'arrow',
     },
     controlPointOffsetRange,
-    lineWidth: REL_LINE_WIDTHS[weight],
+    arrowheadSize: REL_ARROWHEAD_SIZES[weight] * relScale,
   })
 }
 

--- a/core/src/lib/geometry.ts
+++ b/core/src/lib/geometry.ts
@@ -272,6 +272,11 @@ export function mul(multiplier: number, vector: Vector): Vector {
   }
 }
 
+// angle between the x-axis and v
+export function angleX(v: Vector) {
+  return Math.atan2(v.dy, v.dx)
+}
+
 export function norm(v: Vector) {
   return Math.hypot(v.dx, v.dy)
 }


### PR DESCRIPTION
1. Rel arrowheads are now triangles.
2. Fixed a bug where the rel edges were not precisely attached to the item edges. Also if there is an arrowhead at the end, the curve endpoint now starts at the triangle center. 