### PR TITLE
Duplicate image assets when forking

### DIFF
--- a/client/src/components/fork-tapestry-dialog/index.tsx
+++ b/client/src/components/fork-tapestry-dialog/index.tsx
@@ -29,6 +29,7 @@ function ForkProcessDialog({ jobId, onClose }: ForkProcessDialogProps) {
     action: () => resource('tapestryCreateJob').read({ id: jobId }),
     interval: 1000,
     asyncActionOptions: { clearDataOnReload: false },
+    leading: true,
   })
   return (
     <Modal onClose={onClose} title="Copying Tapestry">

--- a/server/src/resources/items.ts
+++ b/server/src/resources/items.ts
@@ -277,13 +277,13 @@ export async function destroyItems(
 
     const items = await tx.item.findMany({
       where: { id: { in: ids } },
-      select: { tapestryId: true, id: true },
+      select: { tapestryId: true, id: true, thumbnailId: true },
     })
     const itemsByTapestry = groupBy(items, (i) => i.tapestryId)
 
     const payload = await tx.item.deleteMany({ where: { id: { in: ids } } })
 
-    const imageAssetIds = compact(items.map((item) => item.tapestryId))
+    const imageAssetIds = compact(items.map((item) => item.thumbnailId))
     if (imageAssetIds.length > 0) {
       await tx.imageAsset.deleteMany({ where: { id: { in: imageAssetIds } } })
     }

--- a/server/src/tasks/autoconsent.ts
+++ b/server/src/tasks/autoconsent.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { Page } from 'puppeteer'
@@ -9,23 +8,20 @@ import {
   ContentScriptMessage,
   RuleBundle,
 } from '@duckduckgo/autoconsent'
+import { createRequire } from 'node:module'
 
 export class AutoconsentError extends Error {}
 
+const requireResolve = createRequire(import.meta.url).resolve
+
 export const autoconsentScript = readFileSync(
-  resolve(
-    dirname(fileURLToPath(import.meta.resolve('@duckduckgo/autoconsent'))),
-    'autoconsent.playwright.js',
-  ),
+  resolve(dirname(requireResolve('@duckduckgo/autoconsent')), 'autoconsent.playwright.js'),
   'utf8',
 )
 
 // Load the rule bundles shipped with the package
-const rules = JSON.parse(
-  readFileSync(
-    fileURLToPath(import.meta.resolve('@duckduckgo/autoconsent/rules/rules.json')),
-    'utf8',
-  ),
+export const rules = JSON.parse(
+  readFileSync(requireResolve('@duckduckgo/autoconsent/rules/rules.json'), 'utf8'),
 ) as RuleBundle
 
 // See https://github.com/duckduckgo/autoconsent/blob/main/docs/api.md

--- a/server/src/tasks/create-tapestry.ts
+++ b/server/src/tasks/create-tapestry.ts
@@ -1,10 +1,10 @@
-import { getCopyName, IdMap, isHTTPURL, mapIds } from 'tapestry-core/src/utils.js'
+import { getCopyName, IdMap, idMapToArray, isHTTPURL, mapIds } from 'tapestry-core/src/utils.js'
 import { JobTypeMap } from './index.js'
 import { prisma } from '../db.js'
 import { generateItemKey, s3Service, tapestryKey } from '../services/s3-service.js'
 import { Prisma, PrismaClient, TapestryCreateJob } from '@prisma/client'
 import { ITXClientDenyList } from '@prisma/client/runtime/library'
-import { omit, fromPairs, zip, sumBy } from 'lodash-es'
+import { omit, fromPairs, zip, sumBy, compact } from 'lodash-es'
 import { actionMap, TapestryImportService } from '../services/tapestry-import-service.js'
 import { ACTION_ITEM_TYPES } from 'tapestry-core/src/data-format/schemas/item.js'
 
@@ -71,11 +71,15 @@ async function forkTapestry(job: TapestryCreateJob) {
           }
         }
 
+        const thumbnanilIds = compact(tapestry.items.map((i) => i.thumbnailId))
+        const thumbnailIdMap = fromPairs(thumbnanilIds.map((id) => [id, crypto.randomUUID()]))
+        await cloneImageAssets(thumbnailIdMap, tx)
+
         const itemIdMap = mapIds(
           tapestry.items,
           tapestry.items.map(() => ({ id: crypto.randomUUID() })),
         )
-        await cloneItems(tapestry.items, newTapestryId, tx, itemIdMap, groupIdMap)
+        await cloneItems(tapestry.items, newTapestryId, tx, itemIdMap, groupIdMap, thumbnailIdMap)
 
         await cloneRels(tapestry.rels, newTapestryId, tx, itemIdMap)
 
@@ -151,12 +155,31 @@ async function cloneGroups(
   return fromPairs(zip(groups, newGroups).map(([dto, db]) => [dto!.id, db!.id]))
 }
 
+async function cloneImageAssets(
+  imageAssetIdMap: IdMap<string>,
+  tx: Omit<PrismaClient, ITXClientDenyList>,
+) {
+  await tx.imageAsset.createMany({ data: idMapToArray(imageAssetIdMap).map((id) => ({ id })) })
+
+  const currentRenditions = await tx.imageAssetRendition.findMany({
+    where: { assetId: { in: Object.keys(imageAssetIdMap) } },
+  })
+
+  await tx.imageAssetRendition.createMany({
+    data: currentRenditions.map((rendition) => ({
+      ...omit(rendition, ['id', 'createdAt', 'updatedAt', 'assetId']),
+      assetId: imageAssetIdMap[rendition.assetId]!,
+    })),
+  })
+}
+
 async function cloneItems(
   items: Prisma.ItemGetPayload<null>[],
   newTapestryId: string,
   tx: Omit<PrismaClient, ITXClientDenyList>,
   itemIdMap: IdMap<string>,
   groupIdMap: IdMap<string>,
+  thumbnailIdMap: IdMap<string>,
 ): Promise<IdMap<string>> {
   const newItems = await tx.item.createManyAndReturn({
     data: items.map((item) => ({
@@ -168,6 +191,7 @@ async function cloneItems(
         'groupId',
         'action',
         'actionType',
+        'thumbnailId',
       ]),
       id: itemIdMap[item.id],
       ...((ACTION_ITEM_TYPES as string[]).includes(item.type)
@@ -175,6 +199,7 @@ async function cloneItems(
         : {}),
       groupId: groupIdMap[item.groupId ?? ''],
       tapestryId: newTapestryId,
+      thumbnailId: thumbnailIdMap[item.thumbnailId ?? ''],
     })),
     select: { id: true },
   })

--- a/server/src/tasks/create-tapestry.ts
+++ b/server/src/tasks/create-tapestry.ts
@@ -1,10 +1,10 @@
-import { getCopyName, IdMap, idMapToArray, isHTTPURL, mapIds } from 'tapestry-core/src/utils.js'
+import { getCopyName, IdMap, isHTTPURL, mapIds } from 'tapestry-core/src/utils.js'
 import { JobTypeMap } from './index.js'
 import { prisma } from '../db.js'
 import { generateItemKey, s3Service, tapestryKey } from '../services/s3-service.js'
 import { Prisma, PrismaClient, TapestryCreateJob } from '@prisma/client'
 import { ITXClientDenyList } from '@prisma/client/runtime/library'
-import { omit, fromPairs, zip, sumBy, compact } from 'lodash-es'
+import { omit, sumBy, compact } from 'lodash-es'
 import { actionMap, TapestryImportService } from '../services/tapestry-import-service.js'
 import { ACTION_ITEM_TYPES } from 'tapestry-core/src/data-format/schemas/item.js'
 
@@ -71,15 +71,18 @@ async function forkTapestry(job: TapestryCreateJob) {
           }
         }
 
-        const thumbnanilIds = compact(tapestry.items.map((i) => i.thumbnailId))
-        const thumbnailIdMap = fromPairs(thumbnanilIds.map((id) => [id, crypto.randomUUID()]))
-        await cloneImageAssets(thumbnailIdMap, tx)
-
-        const itemIdMap = mapIds(
-          tapestry.items,
-          tapestry.items.map(() => ({ id: crypto.randomUUID() })),
+        const thumbnailIdMap = await cloneImageAssets(
+          compact(tapestry.items.map((i) => i.thumbnailId)),
+          tx,
         )
-        await cloneItems(tapestry.items, newTapestryId, tx, itemIdMap, groupIdMap, thumbnailIdMap)
+
+        const itemIdMap = await cloneItems(
+          tapestry.items,
+          newTapestryId,
+          tx,
+          groupIdMap,
+          thumbnailIdMap,
+        )
 
         await cloneRels(tapestry.rels, newTapestryId, tx, itemIdMap)
 
@@ -152,36 +155,48 @@ async function cloneGroups(
     select: { id: true },
   })
 
-  return fromPairs(zip(groups, newGroups).map(([dto, db]) => [dto!.id, db!.id]))
+  return mapIds(groups, newGroups)
 }
 
 async function cloneImageAssets(
-  imageAssetIdMap: IdMap<string>,
+  imageAssetIds: string[],
   tx: Omit<PrismaClient, ITXClientDenyList>,
-) {
-  await tx.imageAsset.createMany({ data: idMapToArray(imageAssetIdMap).map((id) => ({ id })) })
-
-  const currentRenditions = await tx.imageAssetRendition.findMany({
-    where: { assetId: { in: Object.keys(imageAssetIdMap) } },
+): Promise<IdMap<string>> {
+  const newImageAssetIds = await tx.imageAsset.createManyAndReturn({
+    data: imageAssetIds.map(() => ({})),
+    select: { id: true },
   })
 
+  const imageAssetIdMap = mapIds(
+    imageAssetIds.map((id) => ({ id })),
+    newImageAssetIds,
+  )
+  const currentRenditions = await tx.imageAssetRendition.findMany({
+    where: { assetId: { in: imageAssetIds } },
+  })
   await tx.imageAssetRendition.createMany({
     data: currentRenditions.map((rendition) => ({
       ...omit(rendition, ['id', 'createdAt', 'updatedAt', 'assetId']),
-      assetId: imageAssetIdMap[rendition.assetId]!,
+      assetId: imageAssetIdMap[rendition.assetId],
     })),
   })
+
+  return imageAssetIdMap
 }
 
 async function cloneItems(
   items: Prisma.ItemGetPayload<null>[],
   newTapestryId: string,
   tx: Omit<PrismaClient, ITXClientDenyList>,
-  itemIdMap: IdMap<string>,
   groupIdMap: IdMap<string>,
   thumbnailIdMap: IdMap<string>,
 ): Promise<IdMap<string>> {
-  const newItems = await tx.item.createManyAndReturn({
+  const itemIdMap = mapIds(
+    items,
+    items.map(() => ({ id: crypto.randomUUID() })),
+  )
+
+  await tx.item.createMany({
     data: items.map((item) => ({
       ...omit(item, [
         'id',
@@ -201,10 +216,9 @@ async function cloneItems(
       tapestryId: newTapestryId,
       thumbnailId: thumbnailIdMap[item.thumbnailId ?? ''],
     })),
-    select: { id: true },
   })
 
-  return fromPairs(zip(items, newItems).map(([dto, db]) => [dto!.id, db!.id]))
+  return itemIdMap
 }
 
 async function cloneRels(

--- a/server/src/tasks/generate-tapestry-thumbnails.ts
+++ b/server/src/tasks/generate-tapestry-thumbnails.ts
@@ -13,7 +13,14 @@ const HEIGHT = Math.floor(WIDTH * (10 / 21))
 
 export async function generateTapestryThumbnails({
   tapestryId,
+  generateAll,
 }: JobTypeMap['generate-tapestry-thumbnails']) {
+  if (generateAll) {
+    await prisma.item.updateMany({
+      where: { tapestryId },
+      data: { scheduledThumbnailProcessing: generateAll },
+    })
+  }
   const tapestry = await prisma.tapestry.findUniqueOrThrow({
     where: { id: tapestryId },
     include: { items: { where: { scheduledThumbnailProcessing: { not: null } } } },

--- a/server/src/tasks/index.ts
+++ b/server/src/tasks/index.ts
@@ -1,6 +1,7 @@
 import { Queue, QueueBaseOptions } from 'bullmq'
 import { config } from '../config.js'
 import { redis } from '../services/redis.js'
+import { ItemDto } from 'tapestry-shared/src/data-transfer/resources/dtos/item.js'
 
 export const QUEUE_NAME = 'tasks'
 
@@ -12,6 +13,7 @@ export const BULLMQ_REDIS_BASE_OPTIONS: QueueBaseOptions = {
 export interface JobTypeMap {
   'generate-tapestry-thumbnails': {
     tapestryId: string
+    generateAll?: ItemDto['scheduledThumbnailProcessing']
   }
   's3-cleanup': void
   'create-tapestry': {


### PR DESCRIPTION
Also:
1. Fixed a bug where deleting an item did not delete its thumbnail image assets.
2. Added option to generate tapestry thumbnail job to generate thumbnails for all items.
3. Changed autoconsent files filename resolution to avoid compilation errors.