### PR TITLE
Fix dashboard cards horizontal order after auto reload

### DIFF
--- a/client/src/components/ai-chat/index.tsx
+++ b/client/src/components/ai-chat/index.tsx
@@ -199,6 +199,7 @@ export function AIChat({ tapestryId, canAttachItems, onPickingItems }: AIChatPro
               </>
             }
             loadingIndicator={<LoadingLogoIcon className={styles.listLoadingIndicator} />}
+            autoScrollFirstElements
           />
         ) : (
           <div />

--- a/client/src/components/comments-list/index.tsx
+++ b/client/src/components/comments-list/index.tsx
@@ -69,6 +69,7 @@ export const CommentsList = memo(({ contextType, contextId, className }: Comment
           </div>
         }
         loadingIndicator={<LoadingLogoIcon className={styles.loadingIndicator} />}
+        autoScrollFirstElements
       />
       <MessageInput
         onSubmit={async (text) => {

--- a/client/src/components/lazy-list/index.tsx
+++ b/client/src/components/lazy-list/index.tsx
@@ -20,7 +20,10 @@ export interface LazyListProps<T extends WithId> extends Partial<LazyListLoaderC
   // Normally the lazy list starts with the first item at the top and the user scrolls down to view more items.
   // If reversed, the list will start with the first item at the bottom and the user needs to scroll up instead.
   reversed?: boolean
+  segmentLength?: number
+  autoScrollFirstElements?: boolean
   className?: string
+  style?: React.CSSProperties
   onLoaderInitialized?: (loader: LazyListLoader<T>) => void
   header?: ReactNode
 }
@@ -49,7 +52,10 @@ export function LazyList<T extends WithId>({
   emptyPlaceholder,
   loadingIndicator,
   reversed,
+  segmentLength,
+  autoScrollFirstElements,
   className,
+  style,
   onLoaderInitialized,
   header,
   ...loaderConfigInit
@@ -62,8 +68,8 @@ export function LazyList<T extends WithId>({
   const initCallbackRef = usePropRef(onLoaderInitialized)
 
   useEffect(() => {
-    void loader.setRequestItems(requestItems)
-  }, [requestItems, loader])
+    void loader.setRequestItems(requestItems, segmentLength)
+  }, [requestItems, segmentLength, loader])
 
   useEffect(() => {
     initCallbackRef.current?.(loader)
@@ -75,7 +81,7 @@ export function LazyList<T extends WithId>({
     const scrolledToFirstElement = reversed
       ? itemOffsetsRef.current.bottomOffset < AUTOSCROLL_EDGE_TOLERANCE
       : list.scrollTop < AUTOSCROLL_EDGE_TOLERANCE
-    if (scrolledToFirstElement && skip === 0) {
+    if (autoScrollFirstElements && scrolledToFirstElement && skip === 0) {
       // If the list is scrolled to the first item, auto-scroll to the edge
       list.scrollTo({ top: reversed ? list.scrollHeight - list.clientHeight : 0 })
     } else {
@@ -95,7 +101,7 @@ export function LazyList<T extends WithId>({
       )
       list.scrollTo({ top: list.scrollTop - mostCommonDisplacement })
     }
-  }, [data, skip, reversed])
+  }, [data, skip, reversed, autoScrollFirstElements])
 
   const items = reversed ? data.toReversed() : data
 
@@ -114,7 +120,7 @@ export function LazyList<T extends WithId>({
   const loadingAfter = data.length + skip < total
 
   return (
-    <div ref={listRef} onScroll={onScroll} className={clsx('lazy-list', className)}>
+    <div ref={listRef} onScroll={onScroll} className={clsx('lazy-list', className)} style={style}>
       {header}
       {(reversed ? loadingAfter : loadingBefore) && <LoadingDots />}
       <div className="list-items-container">

--- a/client/src/components/lazy-list/lazy-list-loader.ts
+++ b/client/src/components/lazy-list/lazy-list-loader.ts
@@ -97,9 +97,11 @@ export class LazyListLoader<T> extends Observable<ListResponseDto<T> & { state: 
   }
 
   private roundToSegment(value: number, round: 'up' | 'down', segmentLength: number) {
-    return round === 'up'
-      ? Math.trunc((value + segmentLength - 1) / segmentLength) * segmentLength
-      : Math.trunc(value / segmentLength) * segmentLength
+    return (
+      (Math.floor(value / segmentLength) +
+        (round === 'up' && value % segmentLength !== 0 ? 1 : 0)) *
+      segmentLength
+    )
   }
 
   /**
@@ -109,7 +111,7 @@ export class LazyListLoader<T> extends Observable<ListResponseDto<T> & { state: 
    */
   setRequestItems(requestItems: LazyListRequestItems<T>, segmentLength?: number) {
     if (segmentLength) {
-      this.requestItems = async (skip: number, limit: number, signal: AbortSignal) => {
+      this.requestItems = async (skip, limit, signal) => {
         const roundedSkip = this.roundToSegment(skip, 'down', segmentLength)
         return requestItems(
           roundedSkip,

--- a/client/src/components/lazy-list/lazy-list-loader.ts
+++ b/client/src/components/lazy-list/lazy-list-loader.ts
@@ -96,8 +96,30 @@ export class LazyListLoader<T> extends Observable<ListResponseDto<T> & { state: 
     }
   }
 
-  setRequestItems(requestItems: LazyListRequestItems<T>) {
-    this.requestItems = requestItems
+  private roundToSegment(value: number, round: 'up' | 'down', segmentLength: number) {
+    return round === 'up'
+      ? Math.trunc((value + segmentLength - 1) / segmentLength) * segmentLength
+      : Math.trunc(value / segmentLength) * segmentLength
+  }
+
+  /**
+   * segmentLength splits the items into segments so that data.length and skip are always
+   * a multiple of segmentLength when possible.
+   * This is useful for grid like lists where a segment corresponds to one row
+   */
+  setRequestItems(requestItems: LazyListRequestItems<T>, segmentLength?: number) {
+    if (segmentLength) {
+      this.requestItems = async (skip: number, limit: number, signal: AbortSignal) => {
+        const roundedSkip = this.roundToSegment(skip, 'down', segmentLength)
+        return requestItems(
+          roundedSkip,
+          this.roundToSegment(limit + skip - roundedSkip, 'up', segmentLength),
+          signal,
+        )
+      }
+    } else {
+      this.requestItems = requestItems
+    }
     this.stop()
     this.killSwitch ??= new AbortController()
     return this.enqueueRequest(this.doReload, 'initial-load')
@@ -164,7 +186,11 @@ export class LazyListLoader<T> extends Observable<ListResponseDto<T> & { state: 
         await this.doReload(signal)
       } else {
         this.update((value) => {
-          value.data.push(...(response.data as Draft<T>[]))
+          value.data.push(
+            ...(response.data.slice(
+              Math.max(0, response.skip - skip - items.length),
+            ) as Draft<T>[]),
+          )
         })
       }
     }, 'load-more')
@@ -190,7 +216,7 @@ export class LazyListLoader<T> extends Observable<ListResponseDto<T> & { state: 
         await this.doReload(signal)
       } else {
         this.update((value) => {
-          value.data.unshift(...(response.data as Draft<T>[]))
+          value.data.unshift(...(response.data.slice(0, skip - response.skip) as Draft<T>[]))
           value.skip = response.skip
         })
       }

--- a/client/src/pages/dashboard/tapestry-list/index.tsx
+++ b/client/src/pages/dashboard/tapestry-list/index.tsx
@@ -2,7 +2,7 @@ import { times } from 'lodash-es'
 import { LazyList } from '../../../components/lazy-list'
 import { SkeletonLoader } from '../skeleton-loader'
 import { TapestryCard } from '../tapestry-card'
-import { ReactNode, useCallback, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useState } from 'react'
 import {
   LazyListLoader,
   LazyListRequestItems,
@@ -14,9 +14,39 @@ import { ListParamsInputDto } from 'tapestry-shared/src/data-transfer/resources/
 import { useSession } from '../../../layouts/session'
 import { NoTapestriesPlaceholder } from './no-tapestries-placeholder'
 import { TapestryWithOwner } from '../../tapestry/view-model'
+import { Breakpoint, breakpointForWidth } from '../../../providers/responsive-provider'
 
 export interface TapestryListItem extends TapestryWithOwner<TapestryDto> {
   isBookmarked: boolean
+}
+
+// For simplicity this includes the gaps
+const XL_MIN_COLUMN_WIDTH = 380
+
+function useTapestryListColumnCount() {
+  const determineColumnCount = () => {
+    switch (breakpointForWidth(window.innerWidth)) {
+      case Breakpoint.XL:
+        return Math.trunc(window.innerWidth / XL_MIN_COLUMN_WIDTH)
+      case Breakpoint.LG:
+        return 3
+      case Breakpoint.MD:
+        return 2
+      case Breakpoint.SM:
+      case Breakpoint.XS:
+        return 1
+    }
+  }
+
+  const [columnCount, setColumnCount] = useState(determineColumnCount())
+
+  useEffect(() => {
+    const onWindowResize = () => setColumnCount(determineColumnCount())
+    window.addEventListener('resize', onWindowResize)
+    return () => window.removeEventListener('resize', onWindowResize)
+  }, [])
+
+  return columnCount
 }
 
 interface TapestryListProps {
@@ -73,12 +103,16 @@ export function TapestryList({
     [filter, orderBy, allBookmarked, userId],
   )
 
+  const columnCount = useTapestryListColumnCount()
+
   return (
     <LazyList
       header={header}
       className={styles.root}
+      style={{ '--column-count': columnCount } as React.CSSProperties}
       loadingEdgeProximity={10}
       requestItems={loadTapestries}
+      segmentLength={columnCount}
       onLoaderInitialized={(loader) => {
         setTapestryLoader(loader)
         onLoaderInitialized?.(loader)

--- a/client/src/pages/dashboard/tapestry-list/index.tsx
+++ b/client/src/pages/dashboard/tapestry-list/index.tsx
@@ -112,7 +112,7 @@ export function TapestryList({
       style={{ '--column-count': columnCount } as React.CSSProperties}
       loadingEdgeProximity={10}
       requestItems={loadTapestries}
-      segmentLength={columnCount}
+      segmentLength={columnCount > 1 ? columnCount : undefined}
       onLoaderInitialized={(loader) => {
         setTapestryLoader(loader)
         onLoaderInitialized?.(loader)

--- a/client/src/pages/dashboard/tapestry-list/styles.module.css
+++ b/client/src/pages/dashboard/tapestry-list/styles.module.css
@@ -6,15 +6,7 @@
   :global(.list-items-container) {
     display: grid;
     gap: 20px;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-
-    @media screen and (width <= 1200px) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-
-    @media screen and (width <= 900px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
+    grid-template-columns: repeat(var(--column-count), 1fr);
 
     @media screen and (width <= 600px) {
       grid-template-columns: minmax(200px, 375px);

--- a/client/src/providers/responsive-provider.tsx
+++ b/client/src/providers/responsive-provider.tsx
@@ -9,7 +9,7 @@ export enum Breakpoint {
   XL = Infinity,
 }
 
-function breakpointForWidth(width: Breakpoint) {
+export function breakpointForWidth(width: Breakpoint) {
   if (width <= Breakpoint.XS) {
     return Breakpoint.XS
   }


### PR DESCRIPTION
Also fixed a bug where the list auto scrolled to the top when the first element got loaded. This is useful for comments when new ones get added, but not for the tapestry list and the IA list