### PR TITLE
Feature - add publisher's info in pdf captures

### DIFF
--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -54,7 +54,34 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
     const value = await convertWebpageToPdf(item.source, {
       width: Math.max(item.width, MIN_PDF_PAGE.width),
       height: Math.max(item.height, MIN_PDF_PAGE.height),
-      margin: { right: 20, left: 20 },
+      margin: { right: 20, left: 20, top: 60 },
+      displayHeaderFooter: true,
+      headerTemplate: `
+      <div style="
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background: #f5f6f8;
+        border: 1px solid #e2e4e8;
+        border-radius: 6px;
+        padding: 6px 12px;
+        margin: 0 30px 0; 
+        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+      ">
+            <span style="
+              font-size: 18px;
+              font-weight: 600;
+              color: #1a1a1a;
+            " class="title"></span>
+            <span style="
+              font-size: 12px;
+              color: #9a9da3;
+              margin-left: 12px;
+            " class="date"></span>
+          </div>
+      `,
+      footerTemplate: `<span></span>`,
     })
 
     const s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -1,7 +1,12 @@
 import { Page, PDFOptions } from 'puppeteer'
 import { JobTypeMap } from '.'
 import { prisma } from '../db'
-import { initWebpage, inNewBrowserPage, scheduleTapestryThumbnailGeneration } from './utils'
+import {
+  initWebpage,
+  inNewBrowserPage,
+  pageEval,
+  scheduleTapestryThumbnailGeneration,
+} from './utils'
 import { s3Service, tapestryKey } from '../services/s3-service'
 import { DBSubscriber } from '../socket'
 import { pick } from 'lodash-es'
@@ -22,24 +27,24 @@ const CONVERT_ITEM_PROPS = [
   'dropShadow',
 ] satisfies (keyof Item)[]
 
-async function getFaviconUrl(page: Page): Promise<string | null> {
-  return page.evaluate((): string | null => {
-    // The project doesn't include lib.dom in server's tsconfig, so
-    // we manually type only the browser API surface we need here.
-    const globalContext = globalThis as unknown as {
-      document: {
-        querySelector: (
-          selector: string,
-        ) => { getAttribute: (attr: string) => string | null } | null
-        baseURI: string
-      }
-    }
+type FaviconWindow = {
+  document: {
+    querySelector: (selector: string) => {
+      getAttribute: (attr: string) => string | null
+    } | null
+    baseURI: string
+  }
+}
 
-    const faviconHref = globalContext.document
+async function getFaviconUrl(page: Page): Promise<string | null> {
+  return pageEval(page, (window) => {
+    const browserWindow = window as FaviconWindow
+
+    const faviconHref = browserWindow.document
       .querySelector('link[rel="icon"], link[rel="shortcut icon"], link[rel="apple-touch-icon"]')
       ?.getAttribute('href')
 
-    return faviconHref ? new URL(faviconHref, globalContext.document.baseURI).href : null
+    return faviconHref ? new URL(faviconHref, browserWindow.document.baseURI).href : null
   })
 }
 
@@ -66,13 +71,12 @@ async function faviconUrlToDataUri(
 
 function buildHeaderTemplate(faviconDataUri: string | null): string {
   return `
-    <div style="width: 100%; display: flex; justify-content: space-between; background: #f5f6f8; border: 1px solid #e2e4e8; padding: 6px 12px; margin: 0 30px 0;">
-      <div style="display: flex; align-items: center; gap: 8px; min-width: 0; max-width: 80%;">
+    <div style="width: 100%; display: flex; box-sizing: border-box; align-items: center; background: #f5f6f8; border: 1px solid #e2e4e8; padding: 6px 12px; margin: 0 30px; overflow: hidden; gap: 16px;">
+      <div style="display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; overflow: hidden;">
         ${faviconDataUri ? `<img src="${faviconDataUri}" style="width: 14px; height: 14px; border-radius: 2px; flex-shrink: 0;" />` : ''}
-        <span style="font-size: 12px; font-weight: 600; color: #1a1a1a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" 
-            class="title"></span>
+        <span style="font-size: 12px; font-weight: 600; color: #1a1a1a; min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" class="title"></span>
       </div>
-      <span style="font-size: 10px; color: #9a9da3; margin-left: 12px; flex-shrink: 0;" class="date"></span>
+      <span style="font-size: 10px; color: #9a9da3; flex-shrink: 0;" class="date"></span>
     </div>
   `
 }
@@ -80,7 +84,7 @@ function buildHeaderTemplate(faviconDataUri: string | null): string {
 const FOOTER_TEMPLATE = `
   <div style="width: 100%; box-sizing: border-box; padding: 0 30px;">
     <div style="display: flex; align-items: center; justify-content: space-between; border-top: 1px solid #e2e4e8; padding-top: 6px;">
-      <span style="font-size: 10px; color: #b0b3ba; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 80%;" class="url"></span>
+      <span style="font-size: 10px; color: #b0b3ba; word-break: break-all; overflow-wrap: anywhere; max-width: 85%;" class="url"></span>
       <span style="font-size: 8px; color: #9a9da3; flex-shrink: 0;">
         <span class="pageNumber"></span> / <span class="totalPages"></span>
       </span>
@@ -157,6 +161,5 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
     })
   } catch (error) {
     console.error(`Error while converting item ${itemId} to pdf`, error)
-    throw error
   }
 }

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -81,16 +81,18 @@ function buildHeaderTemplate(faviconDataUri: string | null): string {
   `
 }
 
-const FOOTER_TEMPLATE = `
-  <div style="width: 100%; box-sizing: border-box; padding: 0 30px;">
-    <div style="display: flex; align-items: center; justify-content: space-between; border-top: 1px solid #e2e4e8; padding-top: 6px;">
-      <span style="font-size: 10px; color: #b0b3ba; word-break: break-all; overflow-wrap: anywhere; max-width: 85%;" class="url"></span>
-      <span style="font-size: 8px; color: #9a9da3; flex-shrink: 0;">
-        <span class="pageNumber"></span> / <span class="totalPages"></span>
-      </span>
+function buildFooterTemplate(pageUrl: string): string {
+  return `
+    <div style="width: 100%; box-sizing: border-box; padding: 0 30px;">
+      <div style="display: flex; align-items: center; justify-content: space-between; border-top: 1px solid #e2e4e8; padding-top: 6px;">
+        <a href="${pageUrl}" style="font-size: 10px; color: #b0b3ba; text-decoration: underline; max-width: 85%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;">${pageUrl}</a>
+        <span style="font-size: 8px; color: #9a9da3; flex-shrink: 0;">
+          <span class="pageNumber"></span> / <span class="totalPages"></span>
+        </span>
+      </div>
     </div>
-  </div>
-`
+  `
+}
 
 async function convertWebpageToPdf(url: string, options?: PDFOptions) {
   let generator: ReturnType<typeof inNewBrowserPage<Uint8Array>> | undefined
@@ -107,7 +109,7 @@ async function convertWebpageToPdf(url: string, options?: PDFOptions) {
         ...options,
         displayHeaderFooter: true,
         headerTemplate: buildHeaderTemplate(faviconDataUri),
-        footerTemplate: FOOTER_TEMPLATE,
+        footerTemplate: buildFooterTemplate(url),
       })
     })
 

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -100,8 +100,7 @@ async function convertWebpageToPdf(url: string, options?: PDFOptions) {
       await initWebpage(page, context, { url, autoconsent: true })
 
       console.log('>  Extracting favicon...')
-      const faviconUrl = await getFaviconUrl(page)
-      const faviconDataUri = await faviconUrlToDataUri(faviconUrl, url)
+      const faviconDataUri = await faviconUrlToDataUri(await getFaviconUrl(page), url)
 
       console.log('>  Converting to pdf...')
       yield page.pdf({

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -60,7 +60,7 @@ async function faviconUrlToDataUri(
 
     const buffer = await res.arrayBuffer()
     const base64 = Buffer.from(buffer).toString('base64')
-    const contentType = res.headers.get('content-type') || 'image/x-icon'
+    const contentType = res.headers.get('content-type') ?? 'image/x-icon'
 
     return `data:${contentType};base64,${base64}`
   } catch (error) {

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -24,6 +24,8 @@ const CONVERT_ITEM_PROPS = [
 
 async function getFaviconUrl(page: Page): Promise<string | null> {
   return page.evaluate((): string | null => {
+    // The project doesn't include lib.dom in server's tsconfig, so
+    // we manually type only the browser API surface we need here.
     const globalContext = globalThis as unknown as {
       document: {
         querySelector: (
@@ -64,65 +66,22 @@ async function faviconUrlToDataUri(
 
 function buildHeaderTemplate(faviconDataUri: string | null): string {
   return `
-    <div style="
-      width: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      background: #f5f6f8;
-      border: 1px solid #e2e4e8;
-      border-radius: 6px;
-      padding: 6px 12px;
-      margin: 0 30px 0;
-    ">
-      <div style="display: flex; align-items: center; gap: 8px; min-width: 0; max-width: 75%;">
+    <div style="width: 100%; display: flex; justify-content: space-between; background: #f5f6f8; border: 1px solid #e2e4e8; padding: 6px 12px; margin: 0 30px 0;">
+      <div style="display: flex; align-items: center; gap: 8px; min-width: 0; max-width: 80%;">
         ${faviconDataUri ? `<img src="${faviconDataUri}" style="width: 14px; height: 14px; border-radius: 2px; flex-shrink: 0;" />` : ''}
-        <span style="
-          font-size: 13px;
-          font-weight: 600;
-          color: #1a1a1a;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        " class="title"></span>
+        <span style="font-size: 12px; font-weight: 600; color: #1a1a1a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" 
+            class="title"></span>
       </div>
-      <span style="
-        font-size: 11px;
-        color: #9a9da3;
-        margin-left: 12px;
-        flex-shrink: 0;
-      " class="date"></span>
+      <span style="font-size: 10px; color: #9a9da3; margin-left: 12px; flex-shrink: 0;" class="date"></span>
     </div>
   `
 }
 
 const FOOTER_TEMPLATE = `
-  <div style="
-    width: 100%;
-    box-sizing: border-box;
-    padding: 0 30px;
-  ">
-    <div style="
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      border-top: 1px solid #e2e4e8;
-      padding-top: 6px;
-    ">
-      <span style="
-        font-size: 9px;
-        color: #b0b3ba;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 70%;
-      " class="url"></span>
-      <span style="
-        font-size: 8px;
-        color: #9a9da3;
-        letter-spacing: 0.3px;
-        flex-shrink: 0;
-      ">
+  <div style="width: 100%; box-sizing: border-box; padding: 0 30px;">
+    <div style="display: flex; align-items: center; justify-content: space-between; border-top: 1px solid #e2e4e8; padding-top: 6px;">
+      <span style="font-size: 10px; color: #b0b3ba; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 80%;" class="url"></span>
+      <span style="font-size: 8px; color: #9a9da3; flex-shrink: 0;">
         <span class="pageNumber"></span> / <span class="totalPages"></span>
       </span>
     </div>

--- a/server/src/tasks/convert-to-pdf.ts
+++ b/server/src/tasks/convert-to-pdf.ts
@@ -1,4 +1,4 @@
-import { PDFOptions } from 'puppeteer'
+import { Page, PDFOptions } from 'puppeteer'
 import { JobTypeMap } from '.'
 import { prisma } from '../db'
 import { initWebpage, inNewBrowserPage, scheduleTapestryThumbnailGeneration } from './utils'
@@ -22,14 +22,131 @@ const CONVERT_ITEM_PROPS = [
   'dropShadow',
 ] satisfies (keyof Item)[]
 
+async function getFaviconUrl(page: Page): Promise<string | null> {
+  return page.evaluate((): string | null => {
+    const globalContext = globalThis as unknown as {
+      document: {
+        querySelector: (
+          selector: string,
+        ) => { getAttribute: (attr: string) => string | null } | null
+        baseURI: string
+      }
+    }
+
+    const faviconHref = globalContext.document
+      .querySelector('link[rel="icon"], link[rel="shortcut icon"], link[rel="apple-touch-icon"]')
+      ?.getAttribute('href')
+
+    return faviconHref ? new URL(faviconHref, globalContext.document.baseURI).href : null
+  })
+}
+
+async function faviconUrlToDataUri(
+  faviconUrl: string | null,
+  pageUrl: string,
+): Promise<string | null> {
+  const url = faviconUrl ?? `${new URL(pageUrl).origin}/favicon.ico`
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(3000) })
+    if (!res.ok) return null
+
+    const buffer = await res.arrayBuffer()
+    const base64 = Buffer.from(buffer).toString('base64')
+    const contentType = res.headers.get('content-type') || 'image/x-icon'
+
+    return `data:${contentType};base64,${base64}`
+  } catch (error) {
+    console.error('>  Failed to fetch favicon', error instanceof Error ? error.message : error)
+    return null
+  }
+}
+
+function buildHeaderTemplate(faviconDataUri: string | null): string {
+  return `
+    <div style="
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: #f5f6f8;
+      border: 1px solid #e2e4e8;
+      border-radius: 6px;
+      padding: 6px 12px;
+      margin: 0 30px 0;
+    ">
+      <div style="display: flex; align-items: center; gap: 8px; min-width: 0; max-width: 75%;">
+        ${faviconDataUri ? `<img src="${faviconDataUri}" style="width: 14px; height: 14px; border-radius: 2px; flex-shrink: 0;" />` : ''}
+        <span style="
+          font-size: 13px;
+          font-weight: 600;
+          color: #1a1a1a;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        " class="title"></span>
+      </div>
+      <span style="
+        font-size: 11px;
+        color: #9a9da3;
+        margin-left: 12px;
+        flex-shrink: 0;
+      " class="date"></span>
+    </div>
+  `
+}
+
+const FOOTER_TEMPLATE = `
+  <div style="
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0 30px;
+  ">
+    <div style="
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-top: 1px solid #e2e4e8;
+      padding-top: 6px;
+    ">
+      <span style="
+        font-size: 9px;
+        color: #b0b3ba;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 70%;
+      " class="url"></span>
+      <span style="
+        font-size: 8px;
+        color: #9a9da3;
+        letter-spacing: 0.3px;
+        flex-shrink: 0;
+      ">
+        <span class="pageNumber"></span> / <span class="totalPages"></span>
+      </span>
+    </div>
+  </div>
+`
+
 async function convertWebpageToPdf(url: string, options?: PDFOptions) {
   let generator: ReturnType<typeof inNewBrowserPage<Uint8Array>> | undefined
   try {
     console.log(`Converting ${url} to pdf...`)
     generator = inNewBrowserPage(async function* (page, context): AsyncGenerator<Uint8Array> {
       await initWebpage(page, context, { url, autoconsent: true })
+
+      console.log('>  Extracting favicon...')
+      const faviconUrl = await getFaviconUrl(page)
+      const faviconDataUri = await faviconUrlToDataUri(faviconUrl, url)
+
       console.log('>  Converting to pdf...')
-      yield page.pdf(options)
+      yield page.pdf({
+        ...options,
+        displayHeaderFooter: true,
+        headerTemplate: buildHeaderTemplate(faviconDataUri),
+        footerTemplate: FOOTER_TEMPLATE,
+      })
     })
 
     const result = await generator.next()
@@ -54,34 +171,7 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
     const value = await convertWebpageToPdf(item.source, {
       width: Math.max(item.width, MIN_PDF_PAGE.width),
       height: Math.max(item.height, MIN_PDF_PAGE.height),
-      margin: { right: 20, left: 20, top: 60 },
-      displayHeaderFooter: true,
-      headerTemplate: `
-      <div style="
-        width: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        background: #f5f6f8;
-        border: 1px solid #e2e4e8;
-        border-radius: 6px;
-        padding: 6px 12px;
-        margin: 0 30px 0; 
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-      ">
-            <span style="
-              font-size: 18px;
-              font-weight: 600;
-              color: #1a1a1a;
-            " class="title"></span>
-            <span style="
-              font-size: 12px;
-              color: #9a9da3;
-              margin-left: 12px;
-            " class="date"></span>
-          </div>
-      `,
-      footerTemplate: `<span></span>`,
+      margin: { right: 20, left: 20, top: 60, bottom: 60 },
     })
 
     const s3Key = tapestryKey(item.tapestryId, `${crypto.randomUUID()}.pdf`, true)
@@ -108,5 +198,6 @@ export async function convertToPdf({ itemId }: JobTypeMap['convert-to-pdf']) {
     })
   } catch (error) {
     console.error(`Error while converting item ${itemId} to pdf`, error)
+    throw error
   }
 }


### PR DESCRIPTION
Add additional information about the website publisher in the generated header/footer:
Header:
- Favicon of the page 
- Page title
- Date the pdf was generate

Footer:
- Page URL
- Pagination

<img width="872" height="934" alt="Screenshot from 2026-08-24 12-14-51" src="https://github.com/user-attachments/assets/2c205cc1-9a9d-4e4f-a60b-f20a8172b8ff" />
<img width="872" height="934" alt="Screenshot from 2026-08-24 12-15-53" src="https://github.com/user-attachments/assets/00f00d48-eb1b-4779-93a8-1de5008de124" />
