### PR TITLE
Fix refresh token logic

### DIFF
--- a/client/src/pages/tapestry/view-model/socket-manager.ts
+++ b/client/src/pages/tapestry/view-model/socket-manager.ts
@@ -20,7 +20,7 @@ export type TapestryUpdated = TypedEvent<'tapestry-updated', TapestryUpdate>
 export class SocketManager extends TypedEventTarget<TapestryUpdated | RTCSignallerEvent> {
   private socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
     new URL(config.apiUrl).origin,
-    { path: SOCKET_PATH, autoConnect: false, auth: (cb) => cb({ token: auth.token }) },
+    { path: SOCKET_PATH, autoConnect: false, auth: (cb) => cb({ token: auth.accessToken?.token }) },
   )
   private isSignallerActivated = false
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -7,7 +7,6 @@ import { ErrorResponseDto } from 'tapestry-shared/src/data-transfer/resources/dt
 import { auth } from '../auth'
 
 class APIService {
-  private accessToken: string | null = null
   private axiosInstance: AxiosInstance
 
   constructor() {
@@ -41,16 +40,16 @@ class APIService {
     return this.request<void>(path, { method: 'DELETE', ...config })
   }
 
-  setAccessToken(token: string | null) {
-    this.accessToken = token
-  }
-
   private async request<T>(path: string, config: AxiosRequestConfig): Promise<T> {
     try {
+      if (auth.accessToken && auth.accessToken.expiresAt < Date.now()) {
+        await auth.refresh(false, config.signal)
+      }
+
       const { data } = await this.axiosInstance<T>(path, {
         ...config,
         headers: {
-          ...(this.accessToken ? { Authorization: `Bearer ${this.accessToken}` } : {}),
+          ...(auth.accessToken ? { Authorization: `Bearer ${auth.accessToken.token}` } : {}),
           ...config.headers,
           ...(config.data instanceof File ? { 'Content-Type': 'application/octet-stream' } : {}),
         },

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -1,10 +1,14 @@
 import { UserDto } from 'tapestry-shared/src/data-transfer/resources/dtos/user'
 import { resource } from './rest-resources'
-import { api } from './api'
 import { Observable } from 'tapestry-core-client/src/lib/events/observable'
 import { CanceledError, GenericAbortSignal } from 'axios'
 import { SessionCreateDto } from 'tapestry-shared/src/data-transfer/resources/dtos/session'
 import { APIError } from '../errors'
+
+interface Token {
+  token: string
+  expiresAt: number
+}
 
 export interface AuthServiceState {
   user: UserDto | null
@@ -37,10 +41,10 @@ export abstract class AuthService<
 > extends Observable<AuthServiceState> {
   private autoRefreshTimeout: number | undefined
   private preparing = defer()
-  private accessToken?: string
+  private _accessToken: Token | null = null
 
-  get token() {
-    return this.accessToken
+  get accessToken() {
+    return structuredClone(this._accessToken)
   }
 
   constructor() {
@@ -69,7 +73,7 @@ export abstract class AuthService<
     try {
       // We don't want to send the old access token (if any) when refreshing the session
       // because if it is invalid, it would cause an InvalidAccessTokenError.
-      api.setAccessToken(null)
+      this._accessToken = null
       const { accessToken, user, expiresAt } = await resource('sessions').create(
         params,
         { include: loadUser ? ['user'] : undefined },
@@ -81,8 +85,7 @@ export abstract class AuthService<
         clearTimeout(this.autoRefreshTimeout)
         this.autoRefreshTimeout = window.setTimeout(this.refresh.bind(this), renewAfter)
       }
-      api.setAccessToken(accessToken)
-      this.accessToken = accessToken
+      this._accessToken = { token: accessToken, expiresAt }
       this.update((state) => {
         state.user = user ?? state.user ?? null
         state.isInitialized = true
@@ -121,7 +124,7 @@ export abstract class AuthService<
     if (!this.value.user) return
 
     await resource('sessions').destroy({ id: this.value.user.id }, { signal })
-    api.setAccessToken(null)
+    this._accessToken = null
     this.update((state) => {
       state.user = null
     })


### PR DESCRIPTION
1. For some reason the request from the autorefresh timeout fails from time to time. 
2. If we are on the dashboard after the autorefresh failed, we continue to send the invalid(expired) access token, but don't receive 401, since the tapestries API and others also can accept requests from both authorized and unauthorized users. If we don't receive 401 a new refresh attempt is not triggered.
3. That is why I added an additional expiration check before using the access token on the client