### PR TITLE
Support HEIC/HEIF image import

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -35,6 +35,7 @@ RUN apk add --no-cache \
   yarn \
   ffmpeg \
   imagemagick \
+  libheif-tools \
   ghostscript;
 
 COPY --from=server /app /app

--- a/client/src/components/tapestry-elements/items/image/index.tsx
+++ b/client/src/components/tapestry-elements/items/image/index.tsx
@@ -1,5 +1,10 @@
 import { memo } from 'react'
-import { ImageItemViewer } from 'tapestry-core-client/src/components/tapestry/items/image/viewer'
+import {
+  HeicConvertingPlaceholder,
+  ImageItemViewer,
+} from 'tapestry-core-client/src/components/tapestry/items/image/viewer'
+import { useObservable } from 'tapestry-core-client/src/components/lib/hooks/use-observable'
+import { isHeicSource } from 'tapestry-core/src/utils'
 import { ImageItemDto } from 'tapestry-shared/src/data-transfer/resources/dtos/item'
 import { TapestryItemProps } from '..'
 import { useTapestryData } from '../../../../pages/tapestry/tapestry-providers'
@@ -7,6 +12,7 @@ import { buildToolbarMenu } from '../../item-toolbar'
 import { useItemToolbar } from '../../item-toolbar/use-item-toolbar'
 import { TapestryItem } from '../tapestry-item'
 import { AssignActionButton } from '../../../assign-action-button'
+import { itemUpload } from '../../../../services/item-upload'
 
 export const ImageItem = memo(({ id }: TapestryItemProps) => {
   const isEdit = useTapestryData('interactionMode') === 'edit'
@@ -27,9 +33,17 @@ export const ImageItem = memo(({ id }: TapestryItemProps) => {
     ],
   })
 
+  const uploadingFile = useObservable(itemUpload).find(
+    (item) => item.objectUrl === dto.source,
+  )?.file
+
   return (
     <TapestryItem id={id} halo={toolbar}>
-      <ImageItemViewer id={id} />
+      {uploadingFile && isHeicSource(uploadingFile.name) ? (
+        <HeicConvertingPlaceholder />
+      ) : (
+        <ImageItemViewer id={id} />
+      )}
     </TapestryItem>
   )
 })

--- a/client/src/lib/media.ts
+++ b/client/src/lib/media.ts
@@ -2,6 +2,7 @@ import { pick } from 'lodash-es'
 import { pdfjs } from 'react-pdf'
 import { urlToBlob } from 'tapestry-core-client/src/lib/file'
 import { aspectRatio, clampSize, innerFit, Size } from 'tapestry-core/src/lib/geometry'
+import { isHeicSource } from 'tapestry-core/src/utils'
 import { WEB_SOURCE_PARSERS } from 'tapestry-core/src/web-sources'
 
 export type MediaItemSource = File | string
@@ -43,9 +44,14 @@ function getClampedItemSize(size: Size) {
 }
 
 export async function getImageItemSize(source: MediaItemSource, width?: number): Promise<Size> {
-  const image = await loadImageFromBlob(await mediaSourceToBlob(source))
   const defaultImageWidth = 300
   const imageWidth = width ?? defaultImageWidth
+
+  if (isHeicSource(source instanceof File ? source.name : source)) {
+    return getClampedItemSize({ width: imageWidth, height: imageWidth })
+  }
+
+  const image = await loadImageFromBlob(await mediaSourceToBlob(source))
 
   return getClampedItemSize({
     width: imageWidth,

--- a/core-client/src/components/tapestry/items/image/styles.module.css
+++ b/core-client/src/components/tapestry/items/image/styles.module.css
@@ -1,0 +1,19 @@
+.loading-placeholder {
+  position: absolute;
+  inset: 0;
+
+  .spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.placeholder {
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-neutral-0);
+  align-items: center;
+  justify-content: center;
+}

--- a/core-client/src/components/tapestry/items/image/viewer.tsx
+++ b/core-client/src/components/tapestry/items/image/viewer.tsx
@@ -2,11 +2,30 @@ import { useMediaSource } from '../../../lib/hooks/use-media-source'
 import { memo } from 'react'
 import { TapestryElementComponentProps, useTapestryConfig } from '../..'
 import { ImageItem as ImageItemDto } from 'tapestry-core/src/data-format/schemas/item'
+import { isHeicSource } from 'tapestry-core/src/utils'
+import { LoadingSpinner } from '../../../lib/loading-spinner/index'
+import { ItemPlaceholder } from '../../item-placeholder'
+import styles from './styles.module.css'
+
+export function HeicConvertingPlaceholder() {
+  return (
+    <div className={styles.loadingPlaceholder}>
+      <ItemPlaceholder classes={{ root: styles.placeholder }} icon="image">
+        Converting...
+      </ItemPlaceholder>
+      <LoadingSpinner size="48px" className={styles.spinner} />
+    </div>
+  )
+}
 
 export const ImageItemViewer = memo(({ id }: TapestryElementComponentProps) => {
   const { useStoreData } = useTapestryConfig()
   const { source } = useStoreData(`items.${id}.dto`) as ImageItemDto
   const src = useMediaSource(source)
+
+  if (isHeicSource(source)) {
+    return <HeicConvertingPlaceholder />
+  }
 
   return (
     <img

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -160,3 +160,8 @@ export function determineImageFormat(url: string) {
 
   return mimeType.split('/')[1]
 }
+
+export function isHeicSource(source: string) {
+  const [, extension] = fileExtension(source.split(/[?#]/)[0])
+  return extension === 'heic' || extension === 'heif'
+}

--- a/server/src/resources/items.ts
+++ b/server/src/resources/items.ts
@@ -16,7 +16,13 @@ import {
   MediaItemUpdateDto,
 } from 'tapestry-shared/src/data-transfer/resources/dtos/item.js'
 import { ReadParamsDto } from 'tapestry-shared/src/data-transfer/resources/dtos/common.js'
-import { determineImageFormat, ensureArray, OneOrMore } from 'tapestry-core/src/utils.js'
+import {
+  determineImageFormat,
+  ensureArray,
+  isHeicSource,
+  isHTTPURL,
+  OneOrMore,
+} from 'tapestry-core/src/utils.js'
 import { socketIdFromRequest, socketServer } from '../socket/index.js'
 import { compact, get, groupBy, isEmpty, omit } from 'lodash-es'
 import { findWebSourceParser } from 'tapestry-core/src/web-sources/index.js'
@@ -111,6 +117,24 @@ async function scheduleConvertToPdf(item: ItemWithAssets) {
   )
 }
 
+function isHeicImageItem(item: Pick<Item, 'type' | 'source'>) {
+  return (
+    item.type === 'image' && !!item.source && !isHTTPURL(item.source) && isHeicSource(item.source)
+  )
+}
+
+async function scheduleConvertHeicImage(item: Pick<Item, 'id'>) {
+  await queue.add(
+    'convert-heic-image',
+    { itemId: item.id },
+    {
+      removeOnComplete: true,
+      removeOnFail: true,
+      jobId: item.id,
+    },
+  )
+}
+
 async function processThumbnailUpdate(
   item: Item,
   thumbnailUpdate: ItemUpdateDto['thumbnail'] | null | undefined,
@@ -183,14 +207,21 @@ export async function createItems(
     include: parseItemIncludes(query?.include),
   })) as ItemWithAssets[]
 
+  const heicItems = dbItems.filter(isHeicImageItem)
+  const heicItemIds = new Set(heicItems.map((item) => item.id))
+
   const itemIds = dbItems
-    .filter((dbItem) => shouldProcessItemThumbnail(dbItem))
+    .filter((dbItem) => shouldProcessItemThumbnail(dbItem) && !heicItemIds.has(dbItem.id))
     .map((item) => item.id)
 
   await (tx ?? prisma).item.updateMany({
     where: { id: { in: itemIds } },
     data: { scheduledThumbnailProcessing: 'derive' },
   })
+
+  for (const item of heicItems) {
+    await scheduleConvertHeicImage(item)
+  }
 
   const dtos = await serialize('Item', dbItems)
 

--- a/server/src/tasks/convert-heic-image.ts
+++ b/server/src/tasks/convert-heic-image.ts
@@ -1,0 +1,84 @@
+import { unlink, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { noop } from 'lodash-es'
+import sharp from 'sharp'
+import { isHeicSource } from 'tapestry-core/src/utils'
+import { aspectRatio, clampSize } from 'tapestry-core/src/lib/geometry'
+import { JobTypeMap } from '.'
+import { prisma } from '../db'
+import { downloadToTempFile, scheduleTapestryThumbnailGeneration, spawn } from './utils'
+import { s3Service, tapestryKey } from '../services/s3-service'
+import { DBSubscriber } from '../socket'
+
+const HEIC_CONVERT_QUALITY = 92
+const DEFAULT_IMAGE_WIDTH = 300
+const MIN_ITEM_SIZE = { width: 100, height: 40 }
+const MAX_ITEM_SIZE = { width: 2000, height: 2000 }
+
+export async function convertHeicImage({ itemId }: JobTypeMap['convert-heic-image']) {
+  let inputPath = ''
+  let outputPath = ''
+  try {
+    const item = await prisma.item.findUniqueOrThrow({ where: { id: itemId } })
+
+    if (item.type !== 'image' || !item.source || !isHeicSource(item.source)) {
+      throw new Error(`HEIC conversion not applicable for item ${itemId}`)
+    }
+
+    const sourceUrl = await s3Service.getReadObjectUrl(item.source)
+    inputPath = await downloadToTempFile(sourceUrl)
+    outputPath = join(tmpdir(), `${randomUUID()}.jpg`)
+
+    await spawn('heif-convert', [
+      '--quiet',
+      '-q',
+      String(HEIC_CONVERT_QUALITY),
+      inputPath,
+      outputPath,
+    ])
+
+    let converted: Buffer
+    try {
+      converted = await readFile(outputPath)
+    } catch {
+      throw new Error('heif-convert did not produce a single output image (multi-image HEIC?)')
+    }
+
+    const s3Key = tapestryKey(item.tapestryId, `${randomUUID()}.jpg`, true)
+    await s3Service.putObject(s3Key, converted, 'image/jpeg')
+
+    const { width: pixelWidth, height: pixelHeight } = await sharp(converted).metadata()
+    const size =
+      pixelWidth && pixelHeight
+        ? clampSize(
+            {
+              width: DEFAULT_IMAGE_WIDTH,
+              height: DEFAULT_IMAGE_WIDTH / aspectRatio({ width: pixelWidth, height: pixelHeight }),
+            },
+            MIN_ITEM_SIZE,
+            MAX_ITEM_SIZE,
+          )
+        : undefined
+
+    await prisma.item.update({
+      where: { id: item.id },
+      data: { source: s3Key, scheduledThumbnailProcessing: 'derive', ...size },
+    })
+
+    await scheduleTapestryThumbnailGeneration(item.tapestryId, { skipDelay: true })
+
+    await DBSubscriber.fireNotification({
+      name: 'tapestry-updated',
+      tapestryId: item.tapestryId,
+    })
+  } catch (error) {
+    console.error(`Error while converting HEIC item ${itemId}`, error)
+  } finally {
+    await Promise.all([
+      inputPath ? unlink(inputPath).catch(noop) : undefined,
+      outputPath ? unlink(outputPath).catch(noop) : undefined,
+    ])
+  }
+}

--- a/server/src/tasks/index.ts
+++ b/server/src/tasks/index.ts
@@ -22,6 +22,9 @@ export interface JobTypeMap {
   'convert-to-pdf': {
     itemId: string
   }
+  'convert-heic-image': {
+    itemId: string
+  }
 }
 
 export type JobName = keyof JobTypeMap

--- a/server/src/tasks/worker.ts
+++ b/server/src/tasks/worker.ts
@@ -4,6 +4,7 @@ import { generateTapestryThumbnails } from './generate-tapestry-thumbnails.js'
 import { s3Cleanup } from './s3-cleanup.js'
 import { createTapestry } from './create-tapestry.js'
 import { convertToPdf } from './convert-to-pdf.js'
+import { convertHeicImage } from './convert-heic-image.js'
 
 async function processTask(job: Job<JobTypeMap[JobName], void, JobName>) {
   switch (job.name) {
@@ -15,6 +16,8 @@ async function processTask(job: Job<JobTypeMap[JobName], void, JobName>) {
       return createTapestry(job.data as JobTypeMap['create-tapestry'])
     case 'convert-to-pdf':
       return convertToPdf(job.data as JobTypeMap['convert-to-pdf'])
+    case 'convert-heic-image':
+      return convertHeicImage(job.data as JobTypeMap['convert-heic-image'])
   }
 }
 


### PR DESCRIPTION
## Summary

Dropping a `.heic`/`.heif` image currently fails with a generic "Could not import" error — no browser except Safari can decode HEIC, and even there the item would stay HEIC-sourced with no fallback for every other browser.

- Converts HEIC/HEIF images to JPEG server-side after upload, via a new worker job (`convert-heic-image.ts`) using libheif's `heif-convert` (added to the worker image via `apk add libheif-tools`).
- The job also corrects the item's `width`/`height` to the real decoded aspect ratio (using the same clamp/default-width math the client uses), since the client can't know the real size up front for a format it can't decode.
- The client shows a loading placeholder (reusing the existing `ItemPlaceholder`/`LoadingSpinner` pattern already used by the PDF viewer) during both the upload phase and the brief post-upload conversion window, so there's no broken-image flash.
- Scoped intentionally: only locally-uploaded (internally-hosted) sources are converted — an externally-hosted HEIC source is left alone, since converting it would silently turn a by-reference import into a copy. Only single-image HEIC/HEIF is handled — a multi-image sequence (burst/Live Photo) fails cleanly rather than partially.

## Verification

- `heif-convert` tested against a real iPhone HEIC photo, both in isolation and inside the actual built worker Docker image.
- Full end-to-end test against the real running app (drag-and-drop → placeholder → converted image, correct aspect ratio).
- `tsc --build`/eslint/prettier clean across `core`, `core-client`, `client`, `server`.

## Test plan

- [ ] Drag a `.heic`/`.heif` file onto a tapestry canvas
- [ ] Confirm a loading placeholder shows immediately (no broken-image icon)
- [ ] Confirm the image appears with the correct aspect ratio a few seconds later
- [ ] Confirm a normal (non-HEIC) image import is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)