### PR TITLE
Tweak thumbnails

### DIFF
--- a/client/src/pages/tapestry/tapestry-loader.tsx
+++ b/client/src/pages/tapestry/tapestry-loader.tsx
@@ -35,7 +35,7 @@ import { InteractionMode } from './view-model'
 import { TapestryDataSync } from './view-model/tapestry-data-sync'
 import { ThumbnailContainer } from 'tapestry-core-client/src/stage/renderer/thumbnail-container'
 
-const INITIAL_THUMBNAILS_LOAD_TIMEOUT = 12_000
+const INITIAL_THUMBNAILS_LOAD_TIMEOUT = 4_500
 
 function getErrorMessage(error: unknown) {
   if (error instanceof APIError) {

--- a/core-client/src/components/tapestry/tapestry-canvas/index.tsx
+++ b/core-client/src/components/tapestry/tapestry-canvas/index.tsx
@@ -10,7 +10,7 @@ import {
   useTapestryConfig,
 } from '../../../components/tapestry'
 import { themeToDOMWriter } from '../../../theme/theme-to-dom-writer'
-import { ItemViewModel } from '../../../view-model'
+import { ItemViewModel, TapestryViewModel } from '../../../view-model'
 import { getBounds, isItemInSelection, isMultiselection } from '../../../view-model/utils'
 import { PropsWithStyle } from '../../lib'
 import styles from './styles.module.css'
@@ -19,7 +19,43 @@ import { ItemType } from 'tapestry-core/src/data-format/schemas/item'
 import { isMac, isMobile } from '../../../lib/user-agent'
 import { sortByPath } from 'tapestry-core/src/lib/array'
 
-export type TapestryCanvasProps = PropsWithStyle<object, 'root' | 'itemLocator' | 'relLocator'>
+const ITEMS_WITH_THUMBNAIL_PLACEHOLDER: ItemType[] = ['audio', 'video', 'book', 'pdf', 'webpage']
+
+function shouldDisplayThumbnailPlaceholder(item: ItemViewModel) {
+  return (
+    (item.dto.thumbnail?.renditions.length ?? 0) > 0 &&
+    !item.snapshotId &&
+    ITEMS_WITH_THUMBNAIL_PLACEHOLDER.includes(item.dto.type)
+  )
+}
+
+export function shouldDisplayDom(
+  {
+    disableOptimizations,
+    thumbnailsInitialized,
+    isInteractive,
+  }: Pick<TapestryViewModel, 'disableOptimizations' | 'thumbnailsInitialized'> & {
+    isInteractive: boolean
+  },
+  item: ItemViewModel,
+) {
+  return (
+    disableOptimizations ||
+    isInteractive ||
+    item.isPlaying ||
+    (thumbnailsInitialized ? !item.snapshotId : !shouldDisplayThumbnailPlaceholder(item))
+  )
+}
+
+const PERSIST_ITEM_TYPES: ItemType[] = ['audio', 'video', 'book', 'pdf', 'text', 'webpage']
+
+export function hasPersistedState(item: ItemViewModel) {
+  return (
+    item.hasBeenActive && (PERSIST_ITEM_TYPES as (string | undefined)[]).includes(item.dto.type)
+  )
+}
+
+export const displayPersistedState = !(isMobile && isMac)
 
 interface TapestryElementLocatorProps extends PropsWithStyle {
   id: string
@@ -27,14 +63,6 @@ interface TapestryElementLocatorProps extends PropsWithStyle {
   component: TapestryElementComponent
   transform: LinearTransform
 }
-
-const PERSIST_ITEM_TYPES: ItemType[] = ['audio', 'video', 'book', 'pdf', 'text', 'webpage']
-
-export function hasPersistentState(itemType: ItemType) {
-  return (PERSIST_ITEM_TYPES as (string | undefined)[]).includes(itemType)
-}
-
-export const displayPersistedState = !(isMobile && isMac)
 
 function TapestryElementLocator({
   id,
@@ -52,16 +80,17 @@ function TapestryElementLocator({
       'thumbnailsInitialized',
     ])
   const item = useStoreData(`items.${id}`)
+  if (!item) {
+    return null
+  }
   const isInteractive = id === interactiveElement?.modelId
   const isInSelection = isItemInSelection(item, selection)
-  const hasBeenActive = !!item?.hasBeenActive
-  const shouldDisplayDom =
-    disableOptimizations ||
-    isInteractive ||
-    item?.isPlaying ||
-    (thumbnailsInitialized && !item?.snapshotId)
+  const displayDom = shouldDisplayDom(
+    { disableOptimizations, thumbnailsInitialized, isInteractive },
+    item,
+  )
 
-  if (!shouldDisplayDom && !(hasBeenActive && hasPersistentState(item.dto.type))) {
+  if (!displayDom && !hasPersistedState(item)) {
     // The item should currently be hidden since it is not interactive and a placeholder will be displayed instead.
     // In this case we don't want to keep this item in the DOM at all. The only exception is if the user has interacted
     // with the item and we want to preserve its internal state. In this case we want to keep the item in the DOM but
@@ -72,7 +101,7 @@ function TapestryElementLocator({
   return (
     <div
       style={
-        shouldDisplayDom || displayPersistedState
+        displayDom || displayPersistedState
           ? {
               position: 'absolute',
               top: `${top}px`,
@@ -123,6 +152,8 @@ function getRelBounds(rel: Rel, items: IdMap<ItemViewModel>) {
 
   return getBounds(rel, { [fromItem.dto.id]: fromItem, [toItem.dto.id]: toItem })
 }
+
+export type TapestryCanvasProps = PropsWithStyle<object, 'root' | 'itemLocator' | 'relLocator'>
 
 export function TapestryCanvas({ classes, style }: TapestryCanvasProps) {
   const { useStoreData, components } = useTapestryConfig()

--- a/core-client/src/stage/controller/item-thumbnail-controller.ts
+++ b/core-client/src/stage/controller/item-thumbnail-controller.ts
@@ -1,10 +1,10 @@
 import { ImageAssetRendition } from 'tapestry-core/src/data-format/schemas/item'
 import { TapestryStageController } from '.'
 import { Store } from '../../lib/store'
-import { ItemViewModel, TapestryViewModel } from '../../view-model'
+import { ItemViewModel, TapestryViewModel, Viewport } from '../../view-model'
 import { IdMap, idMapToArray } from 'tapestry-core/src/utils'
 import { ORIGIN, Rectangle, scaleSize, Size } from 'tapestry-core/src/lib/geometry'
-import { debounce, minBy, uniqueId } from 'lodash-es'
+import { debounce, maxBy, minBy, uniqueId } from 'lodash-es'
 import { positionAtViewport } from '../../view-model/utils'
 import {
   ThumbnailLoadError,
@@ -58,10 +58,8 @@ export class ItemThumbnailController implements TapestryStageController {
         this.setLoadedRendition(itemId, rendition)
       })
       this.initialThumbnails = undefined
-      this.onInitialized()
-    } else {
-      this.fetchInitialThumbnails()
     }
+    this.fetchInitialThumbnails()
   }
 
   dispose(): void {
@@ -121,6 +119,9 @@ export class ItemThumbnailController implements TapestryStageController {
 
   private fetchInitialThumbnails() {
     for (const item of idMapToArray(this.store.get('items'))) {
+      if (this.thumbnails[item.dto.id]) {
+        continue
+      }
       const thumbnailRenditions = item.dto.thumbnail?.renditions ?? []
       const rendition = minBy(thumbnailRenditions, ({ size }) => size.width)
       if (!rendition) {
@@ -130,6 +131,9 @@ export class ItemThumbnailController implements TapestryStageController {
 
       const requestId = this.requestThumbnailRendition(item.dto.id, rendition)
       this.initialRequestIds.add(requestId)
+    }
+    if (this.initialRequestIds.size === 0) {
+      this.onInitialized()
     }
   }
 
@@ -143,23 +147,33 @@ export class ItemThumbnailController implements TapestryStageController {
     return maxLOD
   }
 
+  private getLoadRect(viewport: Viewport) {
+    const {
+      size,
+      transform: { scale },
+    } = viewport
+
+    const loadMargin = Math.min(size.width, size.height) / 3
+
+    return new Rectangle(positionAtViewport(viewport, ORIGIN), scaleSize(size, 1 / scale)).expand(
+      loadMargin / scale,
+    )
+  }
+
   private recalculateLOD = debounce(() => {
     const viewport = this.store.get('viewport')
-    const viewportRect = new Rectangle(
-      positionAtViewport(viewport, ORIGIN),
-      scaleSize(viewport.size, 1 / viewport.transform.scale),
-    )
+    const loadRect = this.getLoadRect(viewport)
     const items = idMapToArray(this.store.get('items'))
     const maxLOD = this.computeMaxLOD(items.length)
     for (const item of idMapToArray(this.store.get('items'))) {
-      this.recalculateLODForItem(item, viewport.transform.scale, viewportRect, maxLOD)
+      this.recalculateLODForItem(item, viewport.transform.scale, loadRect, maxLOD)
     }
   }, 250)
 
   private recalculateLODForItem(
     item: ItemViewModel,
     scale: number,
-    viewportRect: Rectangle,
+    loadRect: Rectangle,
     maxLOD: number,
     forceReload = false,
   ) {
@@ -176,8 +190,8 @@ export class ItemThumbnailController implements TapestryStageController {
     const { requestedRendition, loadedRendition } = this.thumbnails[itemId]
     const requestedOrLoadedRendition = requestedRendition ?? loadedRendition
 
-    const isVisible = viewportRect.intersects(new Rectangle(item.dto))
-    if (!forceReload && !isVisible && requestedOrLoadedRendition) return
+    const isVisible = loadRect.intersects(new Rectangle(item.dto))
+    if (!forceReload && !isVisible) return
 
     if (
       forceReload ||
@@ -207,15 +221,17 @@ export class ItemThumbnailController implements TapestryStageController {
     // pixel ratio (we want to load higher-resolution images on higher-resolution displays such as retina displays).
     // Thumbnail renditions should have the same aspect ratio as the item, so comparing only width should suffice.
     const levelOfDetail = Math.min(width * Math.min(2, window.devicePixelRatio), maxLOD)
-    return minBy(renditions, ({ size }) => Math.abs(size.width - levelOfDetail))
+    return (
+      minBy(
+        renditions.filter(({ size }) => size.width >= levelOfDetail),
+        ({ size }) => size.width - levelOfDetail,
+      ) ?? maxBy(renditions, ({ size }) => size.width)
+    )
   }
 
   private onItemsChanged = debounce((itemsMap: TapestryViewModel['items']) => {
     const viewport = this.store.get('viewport')
-    const viewportRect = new Rectangle(
-      positionAtViewport(viewport, ORIGIN),
-      scaleSize(viewport.size, 1 / viewport.transform.scale),
-    )
+    const loadRect = this.getLoadRect(viewport)
     const items = idMapToArray(itemsMap)
     const maxLOD = this.computeMaxLOD(items.length)
     for (const item of items) {
@@ -224,7 +240,7 @@ export class ItemThumbnailController implements TapestryStageController {
       if (
         item.dto.thumbnail?.renditions.every((r) => r.source !== requestedOrLoadedRendition?.source)
       ) {
-        this.recalculateLODForItem(item, viewport.transform.scale, viewportRect, maxLOD, true)
+        this.recalculateLODForItem(item, viewport.transform.scale, loadRect, maxLOD, true)
       } else if (!item.dto.thumbnail) {
         this.setLoadedRendition(item.dto.id, null)
       }

--- a/core-client/src/stage/renderer/item-renderer.ts
+++ b/core-client/src/stage/renderer/item-renderer.ts
@@ -11,7 +11,8 @@ import { getItemOverlayScale } from '../../view-model/utils'
 import { roundToPrecision } from 'tapestry-core/src/lib/algebra'
 import {
   displayPersistedState,
-  hasPersistentState,
+  hasPersistedState,
+  shouldDisplayDom,
 } from '../../components/tapestry/tapestry-canvas'
 import { snapshotRegistry } from '../controller/item-thumbnail-controller'
 
@@ -21,6 +22,7 @@ export interface ItemRenderState<I extends ItemViewModel> {
   disableOptimizations?: boolean
   theme: ThemeName
   dropShadow?: ShadowNineSlice
+  thumbnailsInitialized?: boolean
 }
 
 type Icons = Record<
@@ -135,6 +137,7 @@ export class ItemRenderer<I extends ItemViewModel> extends TapestryElementRender
       dropShadow: viewModel.dto.dropShadow
         ? obtainShadowNineSlice(stage.pixi.tapestry.app.renderer, 8)
         : undefined,
+      thumbnailsInitialized: store.get('thumbnailsInitialized'),
     }
   }
 
@@ -149,19 +152,18 @@ export class ItemRenderer<I extends ItemViewModel> extends TapestryElementRender
     disableOptimizations,
     theme,
     dropShadow,
+    thumbnailsInitialized,
   }: ItemRenderState<I>) {
     const snapshot = viewModel.snapshotId && snapshotRegistry[viewModel.snapshotId]
-    const shouldDisplayDom =
-      disableOptimizations || isInteractive || viewModel.isPlaying || !snapshot
     if (
-      shouldDisplayDom ||
-      (viewModel.hasBeenActive && hasPersistentState(viewModel.dto.type) && displayPersistedState)
+      shouldDisplayDom({ disableOptimizations, isInteractive, thumbnailsInitialized }, viewModel) ||
+      (hasPersistedState(viewModel) && displayPersistedState)
     ) {
       this.thumbnail.visible = false
     } else {
       const { position, size } = viewModel.dto
       this.thumbnail.visible = true
-      this.thumbnail.texture = snapshot
+      this.thumbnail.texture = snapshot || 'placeholder'
       this.thumbnail.position = position
       this.thumbnail.update({
         size,

--- a/core-client/src/stage/renderer/thumbnail-container.ts
+++ b/core-client/src/stage/renderer/thumbnail-container.ts
@@ -45,6 +45,7 @@ const DEFAULT_ICON_SIZE = 24
 
 export class ThumbnailContainer extends Container {
   private static iconTextures?: Record<IconName, Texture>
+  private static placeholderTexture = Texture.WHITE
 
   private state: ThumbnailContainerState
   private shadowSprite?: NineSliceSprite
@@ -101,8 +102,10 @@ export class ThumbnailContainer extends Container {
     this.iconTextures = undefined
   }
 
-  private createSprite(texture: Texture) {
-    const sprite = new Sprite(texture)
+  private createSprite(texture: Texture | 'placeholder') {
+    const sprite = new Sprite(
+      texture === 'placeholder' ? ThumbnailContainer.placeholderTexture : texture,
+    )
     sprite.width = this.state.size.width
     sprite.height = this.state.size.height
     return sprite
@@ -119,7 +122,7 @@ export class ThumbnailContainer extends Container {
     this.updateIconPosition()
   }
 
-  set texture(newTexture: Texture | null) {
+  set texture(newTexture: Texture | 'placeholder' | null) {
     if (this.thumbnail) {
       this.thumbnailContainer.removeChild(this.thumbnail)
       this.thumbnail.destroy()
@@ -128,8 +131,8 @@ export class ThumbnailContainer extends Container {
     if (newTexture) {
       this.thumbnail = this.createSprite(newTexture)
       this.thumbnailContainer.addChild(this.thumbnail)
+      this.fitThumbnail()
     }
-    this.fitThumbnail()
   }
 
   private roundCorners() {

--- a/server/src/tasks/generate-tapestry-thumbnails.ts
+++ b/server/src/tasks/generate-tapestry-thumbnails.ts
@@ -7,9 +7,9 @@ import { Item } from '@prisma/client'
 import { generatePrimaryThumbnail, hasInherentThumbnail } from './thumbnail-generators/index.js'
 import { processItemThumbnail } from './process-item-thumbnail.js'
 
-// 6 times the dimensions of the thumbnail as displayed in the UI
-const WIDTH = 6 * 375
-const HEIGHT = Math.floor(WIDTH * (10 / 21))
+// the ratio of the thumbnail as displayed in the UI
+const DESKTOP_WIDTH = 2000
+const DESKTOP_HEIGHT = Math.floor(DESKTOP_WIDTH * (10 / 21))
 
 export async function generateTapestryThumbnails({
   tapestryId,
@@ -42,7 +42,7 @@ export async function generateTapestryThumbnails({
   let thumbnails: ReturnType<typeof takeTapestryScreenshots> | undefined
   try {
     thumbnails = takeTapestryScreenshots(`/t/${tapestryId}`, tapestry.ownerId, {
-      windowSize: { width: WIDTH, height: HEIGHT },
+      windowSize: { width: DESKTOP_WIDTH, height: DESKTOP_HEIGHT },
       timeout: config.worker.tapestryThumbnailGenerationTimeout,
     })
 

--- a/server/src/tasks/thumbnail-generators/tapestry.ts
+++ b/server/src/tasks/thumbnail-generators/tapestry.ts
@@ -10,6 +10,8 @@ import { Item } from '@prisma/client'
 import { innerFit } from 'tapestry-core/src/lib/geometry.js'
 import { initWebpage, inNewBrowserPage, pageEval, WebpageConfig } from '../utils.js'
 
+// the width of the thumbnail as displayed in the UI * max desktop DPI
+const TAPESTRY_THUMBNAIL_WIDTH = 500 * 2
 const MAX_ITEM_SIZE = 2000
 
 async function takeItemScreenshot(page: Page, item: Item) {
@@ -114,7 +116,9 @@ export async function* takeTapestryScreenshots(
 
     // First take a screenshot of the whole tapestry
     const screenshot = await page.screenshot(options)
-    let item = yield await generateThumbnail(Buffer.from(screenshot))
+    let item = yield await generateThumbnail(Buffer.from(screenshot), {
+      maxDim: TAPESTRY_THUMBNAIL_WIDTH,
+    })
 
     if (!item) return
 


### PR DESCRIPTION
1. Reduced initial load timeout
2. Reduced pixelation of thumbnails by always displaying ones with larger LOD.
3. Added a load margin to the viewport rect so that items close to the viewport but not intersecting it get their thumbnails fetched.
4. Added a white thumbnail placeholder in pixi displayed if the thumbnails are not loa are not yet initialized, and the current thumbnail is not loaded.
5. Restructured some TapestryElementLocator logic
6. Reduced tapestry thumbnails size, so they should load faster on the dashboard.