### PR TITLE
Bugfix: deleting elements 

### DIFF
--- a/client/src/pages/tapestry/view-model/tapestry-resources-repo.ts
+++ b/client/src/pages/tapestry/view-model/tapestry-resources-repo.ts
@@ -141,6 +141,28 @@ function createItemPatch(newItem: ItemDto, oldItem: ItemDto) {
   return isEmpty(patch) ? undefined : { ...patch, type: newItem.type }
 }
 
+const ITEM_READONLY_PROPS = [
+  'createdAt',
+  'updatedAt',
+  'tapestry',
+  'scheduledThumbnailProcessing',
+  'thumbnail',
+] as const
+
+const MEDIA_ITEM_READONLY_PROPS = [...ITEM_READONLY_PROPS, 'internallyHosted'] as const
+
+function itemToCreateParams(item: ItemDto): ItemCreateDto & { id: string } {
+  const readonlyProps: readonly string[] = isMediaItem(item)
+    ? MEDIA_ITEM_READONLY_PROPS
+    : ITEM_READONLY_PROPS
+
+  const createParams = Object.fromEntries(
+    Object.entries(item).filter(([key]) => !readonlyProps.includes(key)),
+  ) as ItemCreateDto & { id: string }
+
+  return createParams
+}
+
 type EventTypesMap = {
   socketManager: EventTypes<SocketManager>
 }
@@ -246,7 +268,7 @@ export class TapestryResourcesRepo extends ResourceRepo<TapestryResourceName, Ty
       throw new Error('Cannot create new tapestries!')
     }
     if (resourceName === 'items') {
-      return resource as ItemCreateDto & { id: string }
+      return itemToCreateParams(resource as ItemDto)
     }
     if (resourceName === 'groups') {
       return resource as GroupCreateDto & { id: string }

--- a/client/src/pages/tapestry/view-model/tapestry-resources-repo.ts
+++ b/client/src/pages/tapestry/view-model/tapestry-resources-repo.ts
@@ -27,7 +27,7 @@ import {
   RelUpdateDto,
 } from 'tapestry-shared/src/data-transfer/resources/dtos/rel'
 import { idFilter, listAll, resource, RESTMethodOptions } from '../../../services/rest-resources'
-import { isEmpty, isEqual } from 'lodash-es'
+import { isEmpty, isEqual, omit } from 'lodash-es'
 import {
   BaseResourceDto,
   BatchMutationDto,
@@ -152,15 +152,8 @@ const ITEM_READONLY_PROPS = [
 const MEDIA_ITEM_READONLY_PROPS = [...ITEM_READONLY_PROPS, 'internallyHosted'] as const
 
 function itemToCreateParams(item: ItemDto): ItemCreateDto & { id: string } {
-  const readonlyProps: readonly string[] = isMediaItem(item)
-    ? MEDIA_ITEM_READONLY_PROPS
-    : ITEM_READONLY_PROPS
-
-  const createParams = Object.fromEntries(
-    Object.entries(item).filter(([key]) => !readonlyProps.includes(key)),
-  ) as ItemCreateDto & { id: string }
-
-  return createParams
+  const readonlyProps = isMediaItem(item) ? MEDIA_ITEM_READONLY_PROPS : ITEM_READONLY_PROPS
+  return omit(item, readonlyProps) as ItemCreateDto & { id: string }
 }
 
 type EventTypesMap = {

--- a/client/src/utils/resource-repo.ts
+++ b/client/src/utils/resource-repo.ts
@@ -66,6 +66,7 @@ export abstract class ResourceRepo<
   private head = 0
   private remote: ResourceIdMaps<R, TypeMap>
   private resourceVersions: ResourceVersions<R>
+  private deletedResourceVersions: ResourceVersions<R>
 
   private isDirty = false
   private pushTimeout: number | null = null
@@ -83,6 +84,9 @@ export abstract class ResourceRepo<
 
     this.remote = cloneDeep(workingCopy)
     this.resourceVersions = Object.fromEntries(
+      resourceNames.map((name) => [name, {}]),
+    ) as ResourceVersions<R>
+    this.deletedResourceVersions = Object.fromEntries(
       resourceNames.map((name) => [name, {}]),
     ) as ResourceVersions<R>
   }
@@ -107,6 +111,9 @@ export abstract class ResourceRepo<
    */
   commit(resources: ResourceIdMaps<R, TypeMap>, { skipPush }: CommitOptions = {}) {
     this.resourceVersions = mapValues(resources, (idMap) => mapValues(idMap, () => this.head))
+    this.deletedResourceVersions = Object.fromEntries(
+      this.resourceNames.map((name) => [name, {}]),
+    ) as ResourceVersions<R>
     this.update(() => createDraft(cloneDeep(resources)), { silent: true })
     if (!skipPush) {
       this.requestPush()
@@ -126,11 +133,16 @@ export abstract class ResourceRepo<
 
     for (const { path, op } of patches) {
       if (op === 'remove' && path.length === 2) {
-        // A resource has been removed
+        // A resource has been removed locally. Record the head at which this happened
+        // instead of just dropping the version, so that a still-in-flight
+        // push response for an earlier mutation of this resource can recognize the
+        // delete happened after it and avoid resurrecting the resource.
+        set(this.deletedResourceVersions, path.slice(0, 2), this.head)
         delete this.resourceVersions[path[0] as R][path[1]]
       } else {
-        // A resource has been modified
+        // A resource has been modified (or re/created) locally - it is no longer deleted.
         set(this.resourceVersions, path.slice(0, 2), this.head)
+        delete this.deletedResourceVersions[path[0] as R][path[1]]
       }
     }
 
@@ -176,6 +188,7 @@ export abstract class ResourceRepo<
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             set(workingCopy, resourcePath, resource)
             set(this.resourceVersions, resourcePath, this.head - 1)
+            delete this.deletedResourceVersions[resourceName][resource.id]
           })
           updated.forEach((resource) => {
             const resourcePath = [resourceName, resource.id]
@@ -195,6 +208,7 @@ export abstract class ResourceRepo<
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             delete workingCopy[resourceName][id]
             delete this.resourceVersions[resourceName][id]
+            delete this.deletedResourceVersions[resourceName][id]
           })
         })
       }
@@ -314,9 +328,19 @@ export abstract class ResourceRepo<
       toSetInWorkingCopy.push(...request.destroy!.map((id) => this.remote[resourceName][id]!))
       errors.push(response.destroyed)
     } else {
-      // Deletion has succeeded, at least partially. If some record failed to delete, revert them.
+      // Deletion has succeeded, at least partially. The remote copy always reflects the
+      // server's confirmation of the delete - that's simply a fact now.
       response.destroyed.forEach((id) => delete this.remote[resourceName][id])
-      toRemoveFromWorkingCopy.push(...response.destroyed)
+
+      for (const id of response.destroyed) {
+        const resourcePath = [resourceName, id]
+        const wasRecreatedAfterThisCommit =
+          get(this.resourceVersions, resourcePath, 0) > commitVersion
+        if (!wasRecreatedAfterThisCommit) {
+          toRemoveFromWorkingCopy.push(id)
+        }
+      }
+
       for (const id of new Set(request.destroy).difference(new Set(response.destroyed))) {
         toSetInWorkingCopy.push(cloneDeep(this.remote[resourceName][id]!))
       }
@@ -326,10 +350,17 @@ export abstract class ResourceRepo<
     this.update((workingCopy) => {
       toSetInWorkingCopy.forEach((resource) => {
         const resourcePath = [resourceName, resource.id]
+        const deletedAt = get(this.deletedResourceVersions, resourcePath) as number | undefined
+        const wasDeletedAfterThisCommit = deletedAt !== undefined && deletedAt > commitVersion
+
         // Don't override local changes that may have happened since the push operation started
-        if (get(this.resourceVersions, resourcePath, 0) <= commitVersion) {
+        if (
+          !wasDeletedAfterThisCommit &&
+          get(this.resourceVersions, resourcePath, 0) <= commitVersion
+        ) {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           set(workingCopy, resourcePath, resource)
+          delete this.deletedResourceVersions[resourceName][resource.id]
         }
       })
 


### PR DESCRIPTION
Resolved this issue during Undo/Redo or rapid deletions where a resource could be resurrected by an in-flight server response. When committing patches locally, we now record the commit version (at which a resource was deleted - deletedResourceVersions). During mutation response handling, incoming data is ignored if the resource was deleted after the push request started. Additionally, cleaned up itemToCreateParams using omit to strip read-only properties before re-creating deleted items.